### PR TITLE
[go errors] Remove unneeded dependency on godropbox/errors

### DIFF
--- a/goebpf_mock/mock_map.go
+++ b/goebpf_mock/mock_map.go
@@ -299,9 +299,9 @@ static struct __create_map_def* bpf_map_get_next(struct __create_map_def* curr)
 import "C"
 
 import (
+	"errors"
 	"unsafe"
 
-	"github.com/dropbox/godropbox/errors"
 	"github.com/dropbox/goebpf"
 )
 

--- a/map.go
+++ b/map.go
@@ -136,11 +136,11 @@ import "C"
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"unsafe"
-
-	"github.com/dropbox/godropbox/errors"
 )
 
 type MapType int
@@ -268,8 +268,7 @@ const (
 // Create EbpfMap binary data stored in ELF section
 func newMapFromElfSection(data []byte) (*EbpfMap, error) {
 	if len(data) < mapDefinitionSize {
-		return nil, errors.Newf("Invalid binary representation of BPF map (%d vs %d)",
-			len(data), mapDefinitionSize)
+		return nil, errors.New("Invalid binary representation of BPF map")
 	}
 
 	return &EbpfMap{
@@ -292,8 +291,9 @@ func NewMapFromExistingMapByFd(fd int) (*EbpfMap, error) {
 		unsafe.Pointer(&infoBuf[0]), C.__u32(len(infoBuf)),
 		unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)))
 	if res == -1 {
-		return nil, errors.Newf("ebpf_obj_get_info_by_fd() failed: %v",
-			NullTerminatedStringToString(logBuf[:]))
+		return nil, errors.New(fmt.Sprintf("ebpf_obj_get_info_by_fd() failed: %v",
+			NullTerminatedStringToString(logBuf[:])),
+		)
 	}
 
 	// Read definition
@@ -333,8 +333,9 @@ func NewMapFromExistingMapById(id int) (*EbpfMap, error) {
 	fd := C.ebpf_map_get_fd_by_id(C.__u32(id),
 		unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)))
 	if fd == -1 {
-		return nil, errors.Newf("ebpf_map_get_fd_by_id() failed: %v",
-			NullTerminatedStringToString(logBuf[:]))
+		return nil, errors.New(fmt.Sprintf("ebpf_map_get_fd_by_id() failed: %v",
+			NullTerminatedStringToString(logBuf[:])),
+		)
 	}
 
 	return NewMapFromExistingMapByFd(int(fd))
@@ -365,7 +366,9 @@ func (m *EbpfMap) Create() error {
 		m.Type == MapTypeArrayOfMaps || m.Type == MapTypeProgArray {
 
 		if m.KeySize > 4 {
-			return errors.Newf("Invalid map '%s' key size(%d), must be 4 bytes", m.Name, m.KeySize)
+			return errors.New(
+				fmt.Sprintf("Invalid map '%s' key size(%d), must be 4 bytes", m.Name, m.KeySize),
+			)
 		}
 		// Allow to omit key size
 		if m.KeySize == 0 {
@@ -380,13 +383,13 @@ func (m *EbpfMap) Create() error {
 
 	// Perform few sanity checks
 	if len(m.Name) >= C.BPF_OBJ_NAME_LEN {
-		return errors.Newf("Map name '%s' is too long", m.Name)
+		return errors.New(fmt.Sprintf("Map name '%s' is too long", m.Name))
 	}
 	if m.KeySize < 1 {
-		return errors.Newf("Invalid map '%s' key size(%d)", m.Name, m.KeySize)
+		return errors.New(fmt.Sprintf("Invalid map '%s' key size(%d)", m.Name, m.KeySize))
 	}
 	if m.ValueSize < 1 {
-		return errors.Newf("Invalid map '%s' value size(%d)", m.Name, m.ValueSize)
+		return errors.New(fmt.Sprintf("Invalid map '%s' value size(%d)", m.Name, m.ValueSize))
 	}
 
 	// Per-CPU maps require extra space to store values from ALL possible CPUs
@@ -441,8 +444,9 @@ func (m *EbpfMap) Create() error {
 	))
 
 	if newFd == -1 {
-		return errors.Newf("ebpf_create_map() failed: %s",
-			NullTerminatedStringToString(logBuf[:]))
+		return errors.New(fmt.Sprintf("ebpf_create_map() failed: %s",
+			NullTerminatedStringToString(logBuf[:])),
+		)
 	}
 	m.fd = newFd
 
@@ -458,11 +462,14 @@ func (m *EbpfMap) Create() error {
 			// Destroy just created map
 			err := m.Close()
 			if err != nil {
-				return errors.Newf("ebpf_obj_pin() to '%s' failed: %v, also close() failed: %v",
-					m.PersistentPath, NullTerminatedStringToString(logBuf[:]), err)
+				return errors.New(
+					fmt.Sprintf("ebpf_obj_pin() to '%s' failed: %v, also close() failed: %v",
+						m.PersistentPath, NullTerminatedStringToString(logBuf[:]), err),
+				)
 			}
-			return errors.Newf("ebpf_obj_pin() to '%s' failed: %s",
-				m.PersistentPath, NullTerminatedStringToString(logBuf[:]))
+			return errors.New(fmt.Sprintf("ebpf_obj_pin() to '%s' failed: %s",
+				m.PersistentPath, NullTerminatedStringToString(logBuf[:])),
+			)
 		}
 	}
 
@@ -520,8 +527,9 @@ func (m *EbpfMap) Lookup(ikey interface{}) ([]byte, error) {
 		C.size_t(unsafe.Sizeof(logBuf))))
 
 	if res == -1 {
-		return nil, errors.Newf("ebpf_map_lookup_elem() failed: %s",
-			NullTerminatedStringToString(logBuf[:]))
+		return nil, errors.New(fmt.Sprintf("ebpf_map_lookup_elem() failed: %s",
+			NullTerminatedStringToString(logBuf[:])),
+		)
 	}
 
 	return val, nil
@@ -532,7 +540,7 @@ func (m *EbpfMap) Lookup(ikey interface{}) ([]byte, error) {
 // WARNING: Does NOT work for Per-CPU maps (not an real use case?).
 func (m *EbpfMap) LookupString(ikey interface{}) (string, error) {
 	if m.isPerCpu() {
-		return "", errors.Newf("Not supported for %v", m.Type)
+		return "", errors.New(fmt.Sprintf("LookupString is not supported for %v", m.Type))
 	}
 	val, err := m.Lookup(ikey)
 	if err != nil {
@@ -612,8 +620,9 @@ func (m *EbpfMap) updateImpl(ikey interface{}, ivalue interface{}, op int) error
 		C.size_t(unsafe.Sizeof(logBuf))))
 
 	if res == -1 {
-		return errors.Newf("ebpf_map_update_elem() failed: %s",
-			NullTerminatedStringToString(logBuf[:]))
+		return errors.New(fmt.Sprintf("ebpf_map_update_elem() failed: %s",
+			NullTerminatedStringToString(logBuf[:])),
+		)
 	}
 
 	return nil
@@ -653,8 +662,9 @@ func (m *EbpfMap) Delete(ikey interface{}) error {
 		C.size_t(unsafe.Sizeof(logBuf))))
 
 	if res == -1 {
-		return errors.Newf("ebpf_map_delete_elem() failed: %s",
-			NullTerminatedStringToString(logBuf[:]))
+		return errors.New(fmt.Sprintf("ebpf_map_delete_elem() failed: %s",
+			NullTerminatedStringToString(logBuf[:])),
+		)
 	}
 
 	return nil

--- a/map.go
+++ b/map.go
@@ -291,9 +291,8 @@ func NewMapFromExistingMapByFd(fd int) (*EbpfMap, error) {
 		unsafe.Pointer(&infoBuf[0]), C.__u32(len(infoBuf)),
 		unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)))
 	if res == -1 {
-		return nil, errors.New(fmt.Sprintf("ebpf_obj_get_info_by_fd() failed: %v",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return nil, fmt.Errorf("ebpf_obj_get_info_by_fd() failed: %v",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 
 	// Read definition
@@ -333,9 +332,8 @@ func NewMapFromExistingMapById(id int) (*EbpfMap, error) {
 	fd := C.ebpf_map_get_fd_by_id(C.__u32(id),
 		unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)))
 	if fd == -1 {
-		return nil, errors.New(fmt.Sprintf("ebpf_map_get_fd_by_id() failed: %v",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return nil, fmt.Errorf("ebpf_map_get_fd_by_id() failed: %v",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 
 	return NewMapFromExistingMapByFd(int(fd))
@@ -366,9 +364,7 @@ func (m *EbpfMap) Create() error {
 		m.Type == MapTypeArrayOfMaps || m.Type == MapTypeProgArray {
 
 		if m.KeySize > 4 {
-			return errors.New(
-				fmt.Sprintf("Invalid map '%s' key size(%d), must be 4 bytes", m.Name, m.KeySize),
-			)
+			return fmt.Errorf("Invalid map '%s' key size(%d), must be 4 bytes", m.Name, m.KeySize)
 		}
 		// Allow to omit key size
 		if m.KeySize == 0 {
@@ -383,13 +379,13 @@ func (m *EbpfMap) Create() error {
 
 	// Perform few sanity checks
 	if len(m.Name) >= C.BPF_OBJ_NAME_LEN {
-		return errors.New(fmt.Sprintf("Map name '%s' is too long", m.Name))
+		return fmt.Errorf("Map name '%s' is too long", m.Name)
 	}
 	if m.KeySize < 1 {
-		return errors.New(fmt.Sprintf("Invalid map '%s' key size(%d)", m.Name, m.KeySize))
+		return fmt.Errorf("Invalid map '%s' key size(%d)", m.Name, m.KeySize)
 	}
 	if m.ValueSize < 1 {
-		return errors.New(fmt.Sprintf("Invalid map '%s' value size(%d)", m.Name, m.ValueSize))
+		return fmt.Errorf("Invalid map '%s' value size(%d)", m.Name, m.ValueSize)
 	}
 
 	// Per-CPU maps require extra space to store values from ALL possible CPUs
@@ -444,9 +440,8 @@ func (m *EbpfMap) Create() error {
 	))
 
 	if newFd == -1 {
-		return errors.New(fmt.Sprintf("ebpf_create_map() failed: %s",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return fmt.Errorf("ebpf_create_map() failed: %s",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 	m.fd = newFd
 
@@ -462,14 +457,11 @@ func (m *EbpfMap) Create() error {
 			// Destroy just created map
 			err := m.Close()
 			if err != nil {
-				return errors.New(
-					fmt.Sprintf("ebpf_obj_pin() to '%s' failed: %v, also close() failed: %v",
-						m.PersistentPath, NullTerminatedStringToString(logBuf[:]), err),
-				)
+				return fmt.Errorf("ebpf_obj_pin() to '%s' failed: %v, also close() failed: %v",
+					m.PersistentPath, NullTerminatedStringToString(logBuf[:]), err)
 			}
-			return errors.New(fmt.Sprintf("ebpf_obj_pin() to '%s' failed: %s",
-				m.PersistentPath, NullTerminatedStringToString(logBuf[:])),
-			)
+			return fmt.Errorf("ebpf_obj_pin() to '%s' failed: %s",
+				m.PersistentPath, NullTerminatedStringToString(logBuf[:]))
 		}
 	}
 
@@ -527,9 +519,8 @@ func (m *EbpfMap) Lookup(ikey interface{}) ([]byte, error) {
 		C.size_t(unsafe.Sizeof(logBuf))))
 
 	if res == -1 {
-		return nil, errors.New(fmt.Sprintf("ebpf_map_lookup_elem() failed: %s",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return nil, fmt.Errorf("ebpf_map_lookup_elem() failed: %s",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 
 	return val, nil
@@ -540,7 +531,7 @@ func (m *EbpfMap) Lookup(ikey interface{}) ([]byte, error) {
 // WARNING: Does NOT work for Per-CPU maps (not an real use case?).
 func (m *EbpfMap) LookupString(ikey interface{}) (string, error) {
 	if m.isPerCpu() {
-		return "", errors.New(fmt.Sprintf("LookupString is not supported for %v", m.Type))
+		return "", fmt.Errorf("LookupString is not supported for %v", m.Type)
 	}
 	val, err := m.Lookup(ikey)
 	if err != nil {
@@ -620,9 +611,8 @@ func (m *EbpfMap) updateImpl(ikey interface{}, ivalue interface{}, op int) error
 		C.size_t(unsafe.Sizeof(logBuf))))
 
 	if res == -1 {
-		return errors.New(fmt.Sprintf("ebpf_map_update_elem() failed: %s",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return fmt.Errorf("ebpf_map_update_elem() failed: %s",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 
 	return nil
@@ -662,9 +652,8 @@ func (m *EbpfMap) Delete(ikey interface{}) error {
 		C.size_t(unsafe.Sizeof(logBuf))))
 
 	if res == -1 {
-		return errors.New(fmt.Sprintf("ebpf_map_delete_elem() failed: %s",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return fmt.Errorf("ebpf_map_delete_elem() failed: %s",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 
 	return nil

--- a/program_base.go
+++ b/program_base.go
@@ -47,9 +47,9 @@ static int ebpf_prog_load(const char *name, __u32 prog_type, const void *insns, 
 */
 import "C"
 import (
+	"errors"
+	"fmt"
 	"unsafe"
-
-	"github.com/dropbox/godropbox/errors"
 )
 
 type ProgramType int
@@ -119,7 +119,7 @@ type BaseProgram struct {
 func (prog *BaseProgram) Load() error {
 	// Sanity checks
 	if len(prog.name) >= C.BPF_OBJ_NAME_LEN {
-		return errors.Newf("Program name '%s' is too long", prog.name)
+		return errors.New(fmt.Sprintf("Program name '%s' is too long", prog.name))
 	}
 
 	// Buffer for kernel's verified debug messages
@@ -141,8 +141,9 @@ func (prog *BaseProgram) Load() error {
 		unsafe.Pointer(&logBuf[0]),
 		C.size_t(unsafe.Sizeof(logBuf))))
 	if res == -1 {
-		return errors.Newf("ebpf_prog_load() failed: %s",
-			NullTerminatedStringToString(logBuf[:]))
+		return errors.New(fmt.Sprintf("ebpf_prog_load() failed: %s",
+			NullTerminatedStringToString(logBuf[:])),
+		)
 	}
 	prog.fd = res
 

--- a/program_base.go
+++ b/program_base.go
@@ -119,7 +119,7 @@ type BaseProgram struct {
 func (prog *BaseProgram) Load() error {
 	// Sanity checks
 	if len(prog.name) >= C.BPF_OBJ_NAME_LEN {
-		return errors.New(fmt.Sprintf("Program name '%s' is too long", prog.name))
+		return fmt.Errorf("Program name '%s' is too long", prog.name)
 	}
 
 	// Buffer for kernel's verified debug messages
@@ -141,9 +141,8 @@ func (prog *BaseProgram) Load() error {
 		unsafe.Pointer(&logBuf[0]),
 		C.size_t(unsafe.Sizeof(logBuf))))
 	if res == -1 {
-		return errors.New(fmt.Sprintf("ebpf_prog_load() failed: %s",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return fmt.Errorf("ebpf_prog_load() failed: %s",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 	prog.fd = res
 

--- a/program_xdp.go
+++ b/program_xdp.go
@@ -7,9 +7,9 @@ package goebpf
 import "C"
 
 import (
-	"github.com/vishvananda/netlink"
+	"errors"
 
-	"github.com/dropbox/godropbox/errors"
+	"github.com/vishvananda/netlink"
 )
 
 type XdpResult int
@@ -63,12 +63,12 @@ func (p *xdpProgram) Attach(ifname string) error {
 	iface, err := netlink.LinkByName(ifname)
 	if err != nil {
 		// Most likely no such interface
-		return errors.Wrap(err, "LinkByName() failed:")
+		return err
 	}
 
 	err = netlink.LinkSetXdpFd(iface, p.fd)
 	if err != nil {
-		return errors.Wrap(err, "LinkSetXdpFd() failed:")
+		return err
 	}
 	p.ifname = ifname
 
@@ -83,13 +83,13 @@ func (p *xdpProgram) Detach() error {
 	iface, err := netlink.LinkByName(p.ifname)
 	if err != nil {
 		// Most likely no such interface
-		return errors.Wrap(err, "LinkByName() failed:")
+		return err
 	}
 
 	// Setting eBPF program with FD -1 actually removes it from interface
 	err = netlink.LinkSetXdpFd(iface, -1)
 	if err != nil {
-		return errors.Wrap(err, "LinkSetXdpFd() failed:")
+		return err
 	}
 	p.ifname = ""
 

--- a/program_xdp.go
+++ b/program_xdp.go
@@ -8,6 +8,7 @@ import "C"
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/vishvananda/netlink"
 )
@@ -63,12 +64,12 @@ func (p *xdpProgram) Attach(ifname string) error {
 	iface, err := netlink.LinkByName(ifname)
 	if err != nil {
 		// Most likely no such interface
-		return err
+		return fmt.Errorf("LinkByName() failed: %v", err)
 	}
 
 	err = netlink.LinkSetXdpFd(iface, p.fd)
 	if err != nil {
-		return err
+		return fmt.Errorf("LinkSetXdpFd() failed: %v", err)
 	}
 	p.ifname = ifname
 
@@ -83,13 +84,13 @@ func (p *xdpProgram) Detach() error {
 	iface, err := netlink.LinkByName(p.ifname)
 	if err != nil {
 		// Most likely no such interface
-		return err
+		return fmt.Errorf("LinkByName() failed: %v", err)
 	}
 
 	// Setting eBPF program with FD -1 actually removes it from interface
 	err = netlink.LinkSetXdpFd(iface, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("LinkSetXdpFd() failed: %v", err)
 	}
 	p.ifname = ""
 

--- a/utils.go
+++ b/utils.go
@@ -148,9 +148,8 @@ func GetProgramInfoByFd(fd int) (*ProgramInfo, error) {
 			unsafe.Pointer(&infoBuf[0]), C.__u32(len(infoBuf)),
 			unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)))
 		if res == -1 {
-			return nil, errors.New(fmt.Sprintf("ebpf_obj_get_info_by_fd() failed: %v",
-				NullTerminatedStringToString(logBuf[:])),
-			)
+			return nil, fmt.Errorf("ebpf_obj_get_info_by_fd() failed: %v",
+				NullTerminatedStringToString(logBuf[:]))
 		}
 	}
 
@@ -182,9 +181,8 @@ func GetProgramInfoByFd(fd int) (*ProgramInfo, error) {
 			unsafe.Pointer(&mapsArray[0]), C.__u32(len(mapsArray)),
 			unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)))
 		if res == -1 {
-			return nil, errors.New(fmt.Sprintf("ebpf_obj_get_info_maps() failed: %v",
-				NullTerminatedStringToString(logBuf[:])),
-			)
+			return nil, fmt.Errorf("ebpf_obj_get_info_maps() failed: %v",
+				NullTerminatedStringToString(logBuf[:]))
 		}
 		// Create maps from IDs
 		for _, id := range mapsArray {
@@ -222,9 +220,8 @@ func GetProgramInfoById(id int) (*ProgramInfo, error) {
 	fd := C.ebpf_prog_get_fd_by_id(C.__u32(id),
 		unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)))
 	if fd == -1 {
-		return nil, errors.New(fmt.Sprintf("ebpf_prog_get_fd_by_id() failed: %v",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return nil, fmt.Errorf("ebpf_prog_get_fd_by_id() failed: %v",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 
 	return GetProgramInfoByFd(int(fd))
@@ -240,9 +237,8 @@ func closeFd(fd int) error {
 		C.size_t(unsafe.Sizeof(logBuf))))
 
 	if res == -1 {
-		return errors.New(fmt.Sprintf("close() failed: %s",
-			NullTerminatedStringToString(logBuf[:])),
-		)
+		return fmt.Errorf("close() failed: %s",
+			NullTerminatedStringToString(logBuf[:]))
 	}
 	return nil
 }
@@ -300,7 +296,7 @@ func ParseFlexibleIntegerLittleEndian(rawVal []byte) uint64 {
 
 // Helper to covert key/value to bytes
 func KeyValueToBytes(ival interface{}, size int) ([]byte, error) {
-	overflow := errors.New(fmt.Sprintf("Key/Value is too long (must be at most %d)", size))
+	overflow := fmt.Errorf("Key/Value is too long (must be at most %d)", size)
 
 	var res = make([]byte, size)
 
@@ -364,7 +360,7 @@ func KeyValueToBytes(ival interface{}, size int) ([]byte, error) {
 		copy(res[4:], val.IP)
 		return res, nil
 	default:
-		return nil, errors.New(fmt.Sprintf("Type %T is not supported yet", val))
+		return nil, fmt.Errorf("Type %T is not supported yet", val)
 	}
 
 	return res, nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/dropbox/godropbox/errors"
 )
 
 func TestParseNumOfPossibleCpus(t *testing.T) {
@@ -46,8 +44,7 @@ func TestParseNumOfPossibleCpus(t *testing.T) {
 func TestCloseFd(t *testing.T) {
 	err := closeFd(1111) // Some non-existing fd
 	assert.Error(t, err)
-	msg := err.(errors.DropboxError).GetMessage()
-	assert.Equal(t, "close() failed: Bad file descriptor", msg)
+	assert.Equal(t, "close() failed: Bad file descriptor", err.Error())
 }
 
 func TestNullTerminatedStringToString(t *testing.T) {


### PR DESCRIPTION
It doesn't really make sense to depend on non-standard library to handle errors.
Getting rid of `godropbox/errors` by replacing with standard `errors` / `fmt` packages.