### PR TITLE
Add XDP simple packet counter example

### DIFF
--- a/examples/xdp/packet_counter/.gitignore
+++ b/examples/xdp/packet_counter/.gitignore
@@ -1,0 +1,2 @@
+packet_counter
+*.elf

--- a/examples/xdp/packet_counter/Makefile
+++ b/examples/xdp/packet_counter/Makefile
@@ -1,0 +1,31 @@
+# Copyright (c) 2019 Dropbox, Inc.
+# Full license can be found in the LICENSE file.
+
+GOCMD := go
+GOBUILD := $(GOCMD) build
+GOCLEAN := $(GOCMD) clean
+CLANG := clang
+CLANG_INCLUDE := -I../../..
+
+GO_SOURCE := main.go
+GO_BINARY := packet_counter
+
+EBPF_SOURCE := ebpf_prog/xdp.c
+EBPF_BINARY := ebpf_prog/xdp.elf
+
+all: build_bpf build_go
+
+build_bpf: $(EBPF_BINARY)
+
+build_go: $(GO_BINARY)
+
+clean:
+	$(GOCLEAN)
+	rm -f $(GO_BINARY)
+	rm -f $(EBPF_BINARY)
+
+$(EBPF_BINARY): $(EBPF_SOURCE)
+	$(CLANG) $(CLANG_INCLUDE) -O2 -target bpf -c $^  -o $@
+
+$(GO_BINARY): $(GO_SOURCE)
+	$(GOBUILD) -v -o $@

--- a/examples/xdp/packet_counter/ebpf_prog/xdp.c
+++ b/examples/xdp/packet_counter/ebpf_prog/xdp.c
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 Dropbox, Inc.
+// Full license can be found in the LICENSE file.
+
+// Very simple XDP program for eBPF library integration tests
+
+#include "bpf_helpers.h"
+
+// Ethernet header
+struct ethhdr {
+  __u8 h_dest[6];
+  __u8 h_source[6];
+  __u16 h_proto;
+} __attribute__((packed));
+
+// IPv4 header
+struct iphdr {
+  __u8 ihl : 4;
+  __u8 version : 4;
+  __u8 tos;
+  __u16 tot_len;
+  __u16 id;
+  __u16 frag_off;
+  __u8 ttl;
+  __u8 protocol;
+  __u16 check;
+  __u32 saddr;
+  __u32 daddr;
+} __attribute__((packed));
+
+
+// eBPF map to store IP proto counters (tcp, udp, etc)
+BPF_MAP_DEF(protocols) = {
+    .map_type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(__u32),
+    .value_size = sizeof(__u64),
+    .max_entries = 255,
+};
+BPF_MAP_ADD(protocols);
+
+
+// XDP program //
+SEC("xdp")
+int packet_count(struct xdp_md *ctx) {
+  void *data_end = (void *)(long)ctx->data_end;
+  void *data = (void *)(long)ctx->data;
+
+  // Only IPv4 supported for this example
+  struct ethhdr *ether = data;
+  if (data + sizeof(*ether) > data_end) {
+    return XDP_ABORTED;
+  }
+  if (ether->h_proto == 0x08U) {  // htons(ETH_P_IP) -> 0x08U
+    data += sizeof(*ether);
+    struct iphdr *ip = data;
+    if (data + sizeof(*ip) > data_end) {
+      return XDP_ABORTED;
+    }
+    // Increase counter in "protocols" eBPF map
+    __u32 proto_index = ip->protocol;
+    __u64 *counter = bpf_map_lookup_elem(&protocols, &proto_index);
+    if (counter) {
+      (*counter)++;
+    }
+  }
+
+  return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPLv2";

--- a/examples/xdp/packet_counter/main.go
+++ b/examples/xdp/packet_counter/main.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2019 Dropbox, Inc.
+// Full license can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dropbox/goebpf"
+)
+
+var iface = flag.String("iface", "", "Interface to bind XDP program to")
+var elf = flag.String("elf", "ebpf_prog/xdp.elf", "clang/llvm compiled binary file")
+var programName = flag.String("program", "packet_count", "Name of XDP program (function name)")
+
+func main() {
+	flag.Parse()
+	if *iface == "" {
+		fatalError("-iface is required.")
+	}
+
+	// Create eBPF system / load .ELF files compiled by clang/llvm
+	bpf := goebpf.NewDefaultEbpfSystem()
+	err := bpf.LoadElf(*elf)
+	if err != nil {
+		fatalError("LoadElf() failed: %v", err)
+	}
+	printBpfInfo(bpf)
+
+	// Find protocols eBPF map
+	protocols := bpf.GetMapByName("protocols")
+	if protocols == nil {
+		fatalError("eBPF map 'protocols' not found")
+	}
+
+	// Program name matches function name in xdp.c:
+	//      int packet_count(struct xdp_md *ctx)
+	xdp := bpf.GetProgramByName(*programName)
+	if xdp == nil {
+		fatalError("Program '%s' not found.", *programName)
+	}
+
+	// Load XDP program into kernel
+	err = xdp.Load()
+	if err != nil {
+		fatalError("xdp.Load(): %v", err)
+	}
+
+	// Attach to interface
+	err = xdp.Attach(*iface)
+	if err != nil {
+		fatalError("xdp.Attach(): %v", err)
+	}
+	defer xdp.Detach()
+
+	// Add CTRL+C handler
+	ctrlC := make(chan os.Signal, 1)
+	signal.Notify(ctrlC, os.Interrupt)
+
+	// Print stat every second / exit on CTRL+C
+	fmt.Println("XDP program successfully loaded and attached. Counters refreshed every second.\n")
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			// Print only first 132 numbers (HOPOPT - SCTP)
+			for i := 0; i < 132; i++ {
+				value, err := protocols.LookupInt(i)
+				if err != nil {
+					fatalError("LookupInt failed: %v", err)
+				}
+				if value > 0 {
+					fmt.Printf("%s: %d ", getProtoName(i), value)
+				}
+			}
+			fmt.Printf("\r")
+		case <-ctrlC:
+			fmt.Println("\nDetaching program and exit")
+			return
+		}
+	}
+}
+
+func fatalError(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func printBpfInfo(bpf goebpf.System) {
+	fmt.Println("Maps:")
+	for _, item := range bpf.GetMaps() {
+		m := item.(*goebpf.EbpfMap)
+		fmt.Printf("\t%s: %v, Fd %v\n", m.Name, m.Type, m.GetFd())
+	}
+	fmt.Println("\nPrograms:")
+	for _, prog := range bpf.GetPrograms() {
+		fmt.Printf("\t%s: %v, size %d, license \"%s\"\n",
+			prog.GetName(), prog.GetType(), prog.GetSize(), prog.GetLicense(),
+		)
+
+	}
+	fmt.Println()
+}
+
+// Converts IPPROTO number into string for well known protocols
+func getProtoName(proto int) string {
+	switch proto {
+	case syscall.IPPROTO_ENCAP:
+		return "IPPROTO_ENCAP"
+	case syscall.IPPROTO_GRE:
+		return "IPPROTO_GRE"
+	case syscall.IPPROTO_ICMP:
+		return "IPPROTO_ICMP"
+	case syscall.IPPROTO_IGMP:
+		return "IPPROTO_IGMP"
+	case syscall.IPPROTO_IPIP:
+		return "IPPROTO_IPIP"
+	case syscall.IPPROTO_SCTP:
+		return "IPPROTO_SCTP"
+	case syscall.IPPROTO_TCP:
+		return "IPPROTO_TCP"
+	case syscall.IPPROTO_UDP:
+		return "IPPROTO_UDP"
+	default:
+		return fmt.Sprintf("%v", proto)
+	}
+}


### PR DESCRIPTION
Adding very simple XDP / go program to count packets on interface grouped by L4 protocol.

Example could be built by simple `make`:
```bash
$ make
clang -I../../.. -O2 -target bpf -c ebpf_prog/xdp.c  -o ebpf_prog/xdp.elf
go build -v -o packet_counter
```

Requires `sudo` to run:
```bash
$ sudo ./packet_counter -iface=enp0s3
Maps:
	protocols: Per-CPU array, Fd 5

Programs:
	packet_count: XDP, size 29, license "GPLv2"

XDP program successfully loaded and attached. Counters refreshed every second.

PROTO_ICMP: 2 IPPROTO_TCP: 44 IPPROTO_UDP: 5
^C
Detaching program and exit
```