### PR TITLE
Added Upsert method to map types, which will update an existing entry or insert one if the entry does not exist yet.

### DIFF
--- a/ebpf.go
+++ b/ebpf.go
@@ -64,6 +64,7 @@ type Map interface {
 	LookupString(interface{}) (string, error)
 	Insert(interface{}, interface{}) error
 	Update(interface{}, interface{}) error
+	Upsert(interface{}, interface{}) error
 	Delete(interface{}) error
 }
 

--- a/goebpf_mock/mock_map.go
+++ b/goebpf_mock/mock_map.go
@@ -485,6 +485,11 @@ func (m *MockMap) Update(ikey interface{}, ivalue interface{}) error {
 	return m.Insert(ikey, ivalue)
 }
 
+// Upsert updates existing element in mock map, or inserts one if it did not exist yet
+func (m *MockMap) Upsert(ikey interface{}, ivalue interface{}) error {
+	return m.Insert(ikey, ivalue)
+}
+
 // Delete deletes element from mock map
 // Valid only for non array map types
 func (m *MockMap) Delete(ikey interface{}) error {

--- a/goebpf_mock/mock_map_test.go
+++ b/goebpf_mock/mock_map_test.go
@@ -142,6 +142,22 @@ func TestMockMapHash(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, value)
 
+	//upsert non existing item
+	err = m.Upsert(12, 101)
+	assert.NoError(t, err)
+
+	value, err = m.LookupInt(12)
+	assert.NoError(t, err)
+	assert.Equal(t, 101, value)
+
+	//upsert existing item
+	err = m.Upsert(12, 102)
+	assert.NoError(t, err)
+
+	value, err = m.LookupInt(12)
+	assert.NoError(t, err)
+	assert.Equal(t, 102, value)
+
 	// Delete
 	err = m.Delete(11)
 	assert.NoError(t, err)

--- a/itest/map_test.go
+++ b/itest/map_test.go
@@ -35,6 +35,12 @@ func (ts *mapTestSuite) TestMapHash() {
 	err = m.Insert("empty", "")
 	ts.NoError(err)
 
+	//use upsert to insert
+	err = m.Upsert("upsert1", "upvalue1")
+	ts.NoError(err)
+	err = m.Upsert("upsert2", "upvalue2")
+	ts.NoError(err)
+
 	// Lookup(generic) previously inserted item
 	bval, err := m.Lookup("str123")
 	ts.NoError(err)
@@ -49,6 +55,15 @@ func (ts *mapTestSuite) TestMapHash() {
 	ts.NoError(err)
 	ts.Equal("", sval)
 
+	// Lookup upserted items(string)
+	sval, err = m.LookupString("upsert1")
+	ts.NoError(err)
+	ts.Equal("upvalue1", sval)
+
+	sval, err = m.LookupString("upsert2")
+	ts.NoError(err)
+	ts.Equal("upvalue2", sval)
+
 	// Update item
 	err = m.Update("str123", "newval")
 	ts.NoError(err)
@@ -56,6 +71,14 @@ func (ts *mapTestSuite) TestMapHash() {
 	sval, err = m.LookupString("str123")
 	ts.NoError(err)
 	ts.Equal("newval", sval)
+
+	// update item using upsert
+	err = m.Upsert("upsert1", "newupval")
+	ts.NoError(err)
+	// Lookup again - to verify that value got updated
+	sval, err = m.LookupString("upsert1")
+	ts.NoError(err)
+	ts.Equal("newupval", sval)
 
 	// Delete item
 	err = m.Delete("str1")

--- a/map.go
+++ b/map.go
@@ -654,6 +654,13 @@ func (m *EbpfMap) Update(ikey interface{}, ivalue interface{}) error {
 	return m.updateImpl(ikey, ivalue, bpfExist)
 }
 
+// Upsert updates (replaces) or inserts element at given ikey.
+// Supported ivalue types are: int, uint8, uint16, uint32, int32, uint64, string, []byte, net.IPNet
+//
+func (m *EbpfMap) Upsert(ikey interface{}, ivalue interface{}) error {
+	return m.updateImpl(ikey, ivalue, bpfAny)
+}
+
 // Delete deletes element by given ikey.
 // Array based types are not supported.
 func (m *EbpfMap) Delete(ikey interface{}) error {


### PR DESCRIPTION
A method to insert entries into a map regardless if the entry already existed or not was needed, so looking at sql, the term Upsert was chosen for the name to add this new method.