### PR TITLE
[loader] Fix possible "slice bounds out of range" when one multiple programs in one ELF section

### DIFF
--- a/itest/ebpf_prog/xdp1.c
+++ b/itest/ebpf_prog/xdp1.c
@@ -47,6 +47,12 @@ BPF_MAP_DEF(array_map) = {
 };
 BPF_MAP_ADD(array_map);
 
+BPF_MAP_DEF(perf_map) = {
+    .map_type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
+    .max_entries = 128,
+};
+BPF_MAP_ADD(perfmap);
+
 #define PROG_CNT 2
 BPF_MAP_DEF(programs) = {
     .map_type = BPF_MAP_TYPE_PROG_ARRAY, .max_entries = PROG_CNT,
@@ -115,4 +121,14 @@ int xdp_root3(struct xdp_md *ctx) {
   return XDP_DROP;
 }
 
-char _license[] SEC("license") = "GPLv2";
+SEC("xdp")
+int xdp_perf(struct xdp_md *ctx) {
+  // Simple program that just emits perf event with packet size.
+  __u32 packet_size = ctx->data_end - ctx->data;
+  // Uncomment once support for Perf Events added
+  // bpf_perf_event_output(ctx, &perf_map, BPF_F_CURRENT_CPU, &packet_size, sizeof(packet_size));
+
+  return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/loader.go
+++ b/loader.go
@@ -347,7 +347,7 @@ func loadPrograms(elfFile *elf.File, maps map[string]Map) (map[string]Program, e
 		}
 
 		// One section may contain multiple programs.
-		// Find all programs and it offsets from symbols table, then
+		// Find all programs and their offsets from symbols table, then
 		// reverse sort them by offset (since order is not guaranteed!)
 		offsetToNameMap := map[int]string{}
 		offsetToNameKeys := []int{} // For keys sort
@@ -366,10 +366,6 @@ func loadPrograms(elfFile *elf.File, maps map[string]Map) (map[string]Program, e
 		for _, offset := range offsetToNameKeys {
 			name := offsetToNameMap[offset]
 			size := lastOffset - offset
-			// Check program size
-			if size/bpfInstructionLen > bpfMaxInstructions {
-				return nil, fmt.Errorf("eBPF program '%s' too big (%d)", name, size)
-			}
 			// Create Program instance with type based on section name (e.g. XDP)
 			result[name] = createProgram(name, license, bytecode[offset:offset+size])
 			lastOffset = offset

--- a/loader.go
+++ b/loader.go
@@ -23,7 +23,7 @@ const (
 	LicenseSectionName = "license"
 
 	// Length of BPF instruction
-	bpfInstructionLen  = 8
+	bpfInstructionLen = 8
 	// Other BPF constants that are not present in "golang.org/x/sys/unix"
 	bpfDw          = 0x18 // ld/ldx double word
 	bpfPseudoMapFd = 1    // pseudo map fd (to be replaced with actual fd)

--- a/loader.go
+++ b/loader.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -345,24 +346,32 @@ func loadPrograms(elfFile *elf.File, maps map[string]Map) (map[string]Program, e
 			}
 		}
 
-		// One section may contain multiple programs
-		// Cut section's bytecode into programs based on symbols information
+		// One section may contain multiple programs.
+		// Find all programs and it offsets from symbols table, then
+		// reverse sort them by offset (since order is not guaranteed!)
+		offsetToNameMap := map[int]string{}
+		offsetToNameKeys := []int{} // For keys sort
+		for _, symbol := range symbols {
+			if int(symbol.Section) == sectionIndex && elf.ST_BIND(symbol.Info) == elf.STB_GLOBAL {
+				key := int(symbol.Value)
+				offsetToNameMap[key] = symbol.Name
+				offsetToNameKeys = append(offsetToNameKeys, key)
+			}
+			// Skip others
+		}
+
+		// Slice eBPF programs by reverse sorted offsets from symbol table
+		sort.Sort(sort.Reverse(sort.IntSlice(offsetToNameKeys)))
 		lastOffset := len(bytecode)
-		for i := len(symbols) - 1; i >= 0; i-- {
-			// Skip symbols which are either:
-			// 1. non GLOBAL binded
-			// 2. Don't belong to current section
-			symbol := &symbols[i]
-			if int(symbol.Section) != sectionIndex || elf.ST_BIND(symbol.Info) != elf.STB_GLOBAL {
-				continue
-			}
-			offset := int(symbol.Value)
+		for _, offset := range offsetToNameKeys {
+			name := offsetToNameMap[offset]
 			size := lastOffset - offset
+			// Check program size
 			if size/bpfInstructionLen > bpfMaxInstructions {
-				return nil, fmt.Errorf("eBPF program '%s' too big", symbol.Name)
+				return nil, fmt.Errorf("eBPF program '%s' too big (%d)", name, size)
 			}
-			// Create program with type based on section name
-			result[symbol.Name] = createProgram(symbol.Name, license, bytecode[offset:offset+size])
+			// Create Program instance with type based on section name (e.g. XDP)
+			result[name] = createProgram(name, license, bytecode[offset:offset+size])
 			lastOffset = offset
 		}
 	}

--- a/loader.go
+++ b/loader.go
@@ -24,7 +24,6 @@ const (
 
 	// Length of BPF instruction
 	bpfInstructionLen  = 8
-	bpfMaxInstructions = 4094
 	// Other BPF constants that are not present in "golang.org/x/sys/unix"
 	bpfDw          = 0x18 // ld/ldx double word
 	bpfPseudoMapFd = 1    // pseudo map fd (to be replaced with actual fd)


### PR DESCRIPTION
Since order is not guaranteed it could cause something like
```
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 19 [running]:
testing.tRunner.func1(0xc42008e1e0)
	/usr/lib/go-1.10/src/testing/testing.go:742 +0x29d
panic(0x7ffe40, 0xc8bd40)
	/usr/lib/go-1.10/src/runtime/panic.go:502 +0x229
github.com/dropbox/goebpf.loadPrograms(0xc4200dadc0, 0xc420091740, 0x0, 0x0, 0x0)
	/home/belyalov/go/src/github.com/dropbox/goebpf/loader.go:370 +0xfef
github.com/dropbox/goebpf.(*ebpfSystem).LoadElf(0xc42008cd20, 0x87b77c, 0x12, 0x0, 0x0)
	/home/belyalov/go/src/github.com/dropbox/goebpf/loader.go:394 +0x152
```

This PR is also slightly refactors `xdp` integration test.