### PR TITLE
[perf events] Close updates channel on Stop()

### DIFF
--- a/bpf_helpers.h
+++ b/bpf_helpers.h
@@ -801,6 +801,11 @@ UNUSED static int bpf_xdp_adjust_head(struct xdp_md *ctx, int offset) {
   return 0;
 }
 
+UNUSED static int bpf_perf_event_output(void *ctx, void *map, __u64 index, void *data, __u32 size)
+{
+  return 0;
+}
+
 #endif  // of other than __BPF__
 
 // Finally make sure that all types have expected size regardless of platform

--- a/perf_events.go
+++ b/perf_events.go
@@ -124,7 +124,9 @@ func (pe *PerfEvents) StartForAllProcessesAndCPUs(bufferSize int) (<-chan []byte
 func (pe *PerfEvents) Stop() {
 	// Stop poll loop
 	close(pe.stopChannel)
+	// Wait until poll loop stopped, then close updates channel
 	pe.wg.Wait()
+	close(pe.updatesChannel)
 
 	// Release resources
 	for _, handler := range pe.handlers {


### PR DESCRIPTION
Also few minor fixes:
- Refactor `xdpdump` example: use goroutine to process perf events
- Add mock version of `bpf_perf_event_output()` - for cross compilation.