### PR TITLE
[xdp/attach] Fix mode constants.

### DIFF
--- a/itest/xdp_test.go
+++ b/itest/xdp_test.go
@@ -135,6 +135,13 @@ func (ts *xdpTestSuite) TestElfLoad() {
 	err = xdp0.Detach()
 	ts.NoError(err)
 
+	// "lo" interface does not support XDP natively, so should fail
+	err = xdp0.Attach(&goebpf.XdpAttachParams{
+		Interface: "lo",
+		Mode:      goebpf.XdpAttachModeDrv,
+	})
+	ts.Require().Error(err)
+
 	// Unload programs (not required for real use case)
 	for _, program := range eb.GetPrograms() {
 		err = program.Close()

--- a/program_xdp.go
+++ b/program_xdp.go
@@ -34,17 +34,21 @@ const (
 	// NOTE: Kernel will not fallback to Generic XDP if NIC driver failed
 	//       to install XDP program.
 	XdpAttachModeNone XdpAttachMode = 0
-	// XdpAttachModeDrv is native, driver mode (support from driver side required)
-	XdpAttachModeDrv XdpAttachMode = 1
 	// XdpAttachModeSkb is "generic", kernel mode, less performant comparing to native,
 	// but does not requires driver support.
-	XdpAttachModeSkb XdpAttachMode = 2
+	XdpAttachModeSkb XdpAttachMode = (1 << 1)
+	// XdpAttachModeDrv is native, driver mode (support from driver side required)
+	XdpAttachModeDrv XdpAttachMode = (1 << 2)
+	// XdpAttachModeHw suitable for NICs with hardware XDP support
+	XdpAttachModeHw XdpAttachMode = (1 << 3)
 )
 
 // XdpAttachParams used to pass parameters to Attach() call.
 type XdpAttachParams struct {
+	// Interface is string name of interface to attach program to
 	Interface string
-	Mode      XdpAttachMode
+	// Mode is one of XdpAttachMode.
+	Mode XdpAttachMode
 }
 
 func (t XdpResult) String() string {
@@ -96,7 +100,7 @@ func newXdpProgram(name, license string, bytecode []byte) Program {
 //    })
 func (p *xdpProgram) Attach(data interface{}) error {
 	var ifaceName string
-	var attachMode = XdpAttachModeNone
+	var attachMode = XdpAttachModeNone // AutoSelect
 
 	switch x := data.(type) {
 	case string:


### PR DESCRIPTION
I was originally confused by these constants:
```c
/* These are stored into IFLA_XDP_ATTACHED on dump. */
enum {
	XDP_ATTACHED_NONE = 0,
	XDP_ATTACHED_DRV,
	XDP_ATTACHED_SKB,
	XDP_ATTACHED_HW,
};
```

But correct constants are:
```c
#define XDP_FLAGS_UPDATE_IF_NOEXIST	(1U << 0)
#define XDP_FLAGS_SKB_MODE		(1U << 1)
#define XDP_FLAGS_DRV_MODE		(1U << 2)
#define XDP_FLAGS_HW_MODE		(1U << 3)
```

So fixed and itest added.