### PR TITLE
[Mac] Gate all syscall() calls by C define to get rid of warnings

### DIFF
--- a/perf_events_handler.go
+++ b/perf_events_handler.go
@@ -38,12 +38,15 @@ static int perf_event_open(int cpu_id, int pid, void *error_buf, size_t error_si
     };
 
     // Open perf events for given CPU
-    int pmu_fd = syscall(__NR_perf_event_open, &attr, pid, cpu_id, -1, 0);
+#ifdef __linux
+	int pmu_fd = syscall(__NR_perf_event_open, &attr, pid, cpu_id, -1, 0);
     if (pmu_fd <= 0) {
         strncpy(error_buf, strerror(errno), error_size);
     }
-
-    return pmu_fd;
+	return pmu_fd;
+#else
+	return 0;
+#endif
 }
 
 // Enables perf events on pmu_fd create by perf_event_open()

--- a/program_base.go
+++ b/program_base.go
@@ -32,6 +32,7 @@ static int ebpf_prog_load(const char *name, __u32 prog_type, const void *insns, 
 	// program name
 	strncpy((char*)&attr.prog_name, name, BPF_OBJ_NAME_LEN - 1);
 
+#ifdef __linux__
 	int res = syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
 	if (res == -1) {
 		// Try again with log
@@ -40,8 +41,10 @@ static int ebpf_prog_load(const char *name, __u32 prog_type, const void *insns, 
 		attr.log_level = 1;
 		res = syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
 	}
-
 	return res;
+#else
+	return 0;
+#endif
 }
 
 */


### PR DESCRIPTION
Otherwise installing package under Mac produces some noise:
```bash
# github.com/dropbox/goebpf
go/src/github.com/dropbox/goebpf/map.go:33:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/map.go:48:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/map.go:62:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/map.go:75:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/map.go:87:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/map.go:98:11: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/map.go:113:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
# github.com/dropbox/goebpf
go/src/github.com/dropbox/goebpf/perf_events_handler.go:41:18: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
# github.com/dropbox/goebpf
go/src/github.com/dropbox/goebpf/program_base.go:35:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/program_base.go:41:9: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
# github.com/dropbox/goebpf
go/src/github.com/dropbox/goebpf/utils.go:24:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/utils.go:35:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/utils.go:50:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
go/src/github.com/dropbox/goebpf/utils.go:69:12: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:742:6: note: 'syscall' has been explicitly marked deprecated here
# github.com/dropbox/goebpf
```