### PR TITLE
Add io.ReaderAt-based Load method

### DIFF
--- a/ebpf.go
+++ b/ebpf.go
@@ -11,7 +11,7 @@ type System interface {
 	// Read previously compiled eBPF program at the given path
 	LoadElf(path string) error
 	// Read previously compiled eBPF program from an io.ReaderAt
-	Load(r io.ReaderAt) error
+	Load(reader io.ReaderAt) error
 	// Get all defined eBPF maps
 	GetMaps() map[string]Map
 	// Returns Map or nil if not found

--- a/ebpf.go
+++ b/ebpf.go
@@ -3,11 +3,15 @@
 
 package goebpf
 
+import "io"
+
 // System defines interface for eBPF system - top level
 // interface to interact with eBPF system
 type System interface {
-	// Read previously compiled eBPF program
-	LoadElf(fn string) error
+	// Read previously compiled eBPF program at the given path
+	LoadElf(path string) error
+	// Read previously compiled eBPF program from an io.ReaderAt
+	Load(r io.ReaderAt) error
 	// Get all defined eBPF maps
 	GetMaps() map[string]Map
 	// Returns Map or nil if not found

--- a/goebpf_mock/mock_ebpf.go
+++ b/goebpf_mock/mock_ebpf.go
@@ -4,6 +4,8 @@
 package goebpf_mock
 
 import (
+	"io"
+
 	"github.com/dropbox/goebpf"
 )
 
@@ -27,7 +29,12 @@ func NewMockSystem() *MockSystem {
 }
 
 // LoadElf does nothing, just a mock for original LoadElf
-func (m *MockSystem) LoadElf(fn string) error {
+func (m *MockSystem) LoadElf(path string) error {
+	return m.ErrorLoadElf
+}
+
+// Load does nothing, just a mock for original Load
+func (m *MockSystem) Load(r io.ReaderAt) error {
 	return m.ErrorLoadElf
 }
 

--- a/loader.go
+++ b/loader.go
@@ -375,7 +375,7 @@ func loadPrograms(elfFile *elf.File, maps map[string]Map) (map[string]Program, e
 	return result, nil
 }
 
-// Reads ELF file compiled by clang + llvm for target bpf
+// LoadElf reads ELF file compiled by clang + llvm for target bpf
 func (s *ebpfSystem) LoadElf(path string) error {
 	f, err := os.Open(path)
 	if err != nil {
@@ -386,7 +386,7 @@ func (s *ebpfSystem) LoadElf(path string) error {
 	return s.Load(f)
 }
 
-// Reads ELF file compiled by clang + llvm for target bpf
+// Load reads ELF file compiled by clang + llvm for target bpf
 func (s *ebpfSystem) Load(r io.ReaderAt) error {
 	// Read ELF headers
 	elfFile, err := elf.NewFile(r)

--- a/loader.go
+++ b/loader.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -375,13 +376,23 @@ func loadPrograms(elfFile *elf.File, maps map[string]Map) (map[string]Program, e
 }
 
 // Reads ELF file compiled by clang + llvm for target bpf
-func (s *ebpfSystem) LoadElf(fn string) error {
-	// Open/read ELF headers
-	elfFile, err := elf.Open(fn)
+func (s *ebpfSystem) LoadElf(path string) error {
+	f, err := os.Open(path)
 	if err != nil {
 		return err
 	}
-	defer elfFile.Close()
+	defer f.Close()
+
+	return s.Load(f)
+}
+
+// Reads ELF file compiled by clang + llvm for target bpf
+func (s *ebpfSystem) Load(r io.ReaderAt) error {
+	// Read ELF headers
+	elfFile, err := elf.NewFile(r)
+	if err != nil {
+		return err
+	}
 
 	// Load eBPF maps
 	s.Maps, err = loadAndCreateMaps(elfFile)


### PR DESCRIPTION
This allows for embedding a compiled artifact directly into an ebpf program via something like [go-bindata](https://github.com/go-bindata/go-bindata) and wrapping a retrieved asset in something like a `bytes.Reader`.