### PR TITLE
Read pinned maps

### DIFF
--- a/map.go
+++ b/map.go
@@ -431,12 +431,13 @@ func (m *EbpfMap) Create() error {
 	}
 
 	// Per-CPU maps require extra space to store values from ALL possible CPUs
+	// For access from userspace, each value is padded so that it's a multiple of 8 bytes.
 	if m.isPerCpu() {
 		numCpus, err := GetNumOfPossibleCpus()
 		if err != nil {
 			return err
 		}
-		m.valueRealSize = m.ValueSize * numCpus
+		m.valueRealSize = ((m.ValueSize + 7) / 8) * 8 * numCpus
 	} else {
 		m.valueRealSize = m.ValueSize
 	}
@@ -534,7 +535,7 @@ func (m *EbpfMap) CloneTemplate() Map {
 
 // Lookup performs lookup and returns array of bytes
 // WARNING: For Per-CPU array/hash map return value will contain
-// data from all CPUs, i.e. length = valueSize * nCPU
+// data from all CPUs, i.e. length = roundUp(valueSize, 8) * nCPU
 func (m *EbpfMap) Lookup(ikey interface{}) ([]byte, error) {
 	// Convert key into bytes
 	key, err := KeyValueToBytes(ikey, int(m.KeySize))

--- a/map.go
+++ b/map.go
@@ -385,6 +385,31 @@ func NewMapFromExistingMapById(id int) (*EbpfMap, error) {
 	return NewMapFromExistingMapByFd(int(fd))
 }
 
+// NewMapFromExistingMapMapByPath creates eBPF map from a pinned BPF object path.
+// Pinned BPF object is a kernel mechanism to let non owner process to use BPF objects.
+// Common use case - tooling for troubleshoot / inspect existing BPF objects in the kernel.
+func NewMapFromExistingMapByPath(path string) (*EbpfMap, error) {
+	var logBuf [errCodeBufferSize]byte
+
+	pathStr := C.CString(path)
+	defer C.free(unsafe.Pointer(pathStr))
+	fd := C.ebpf_obj_get(pathStr,
+		unsafe.Pointer(&logBuf[0]), C.size_t(unsafe.Sizeof(logBuf)),
+	)
+	if fd == -1 {
+		return nil, fmt.Errorf("ebpf_obj_get() failed: %v",
+			NullTerminatedStringToString(logBuf[:]))
+	}
+
+	m, err := NewMapFromExistingMapByFd(int(fd))
+	if err != nil {
+		return m, err
+	}
+
+	m.PersistentPath = path
+	return m, err
+}
+
 // If map type is Per-CPU based
 func (m *EbpfMap) isPerCpu() bool {
 	return m.Type == MapTypePerCPUArray ||


### PR DESCRIPTION
This PR fixes a couple of issues with PERCPU maps centered around the value array size, and builds on them to introduce `NewMapFromExistingMapByPath` function that's able to read pinned maps.