### PR TITLE
implement bpf_map_get_next_key

### DIFF
--- a/bpf_helpers.h
+++ b/bpf_helpers.h
@@ -243,6 +243,7 @@ struct bpf_sysctl {
      FN(map_lookup_elem),           \
      FN(map_update_elem),           \
      FN(map_delete_elem),           \
+     FN(map_get_next_key),          \
      FN(probe_read),                \
      FN(ktime_get_ns),              \
      FN(trace_printk),              \
@@ -382,6 +383,11 @@ static int (*bpf_map_update_elem)(const void *map, const void *key,
 // Return: 0 on success or negative error
 static int (*bpf_map_delete_elem)(const void *map, void *key) = (void *)  // NOLINT
     BPF_FUNC_map_delete_elem;
+
+// Get next key gets the next key in the map.
+// Return: 0 on success or negative on error
+static int (*bpf_map_get_next_key)(const void *map, const void *key, const void *next_key) = (void *)  // NOLINT
+    BPF_FUNC_map_get_next_key;
 
 static int (*bpf_probe_read)(void *dst, __u64 size, const void *unsafe_ptr) = (void *) // NOLINT
     BPF_FUNC_probe_read;
@@ -811,6 +817,7 @@ void *bpf_map_lookup_elem(const void *map, const void *key);
 int bpf_map_update_elem(const void *map, const void *key, const void *value,
                         __u64 flags);
 int bpf_map_delete_elem(const void *map, const void *key);
+int bpf_map_get_next_key(const void *map, const void *key, const void *next_key);
 
 // bpf_printk() is just printf()
 #define bpf_printk(fmt, ...)  \

--- a/bpf_helpers.h
+++ b/bpf_helpers.h
@@ -817,7 +817,7 @@ void *bpf_map_lookup_elem(const void *map, const void *key);
 int bpf_map_update_elem(const void *map, const void *key, const void *value,
                         __u64 flags);
 int bpf_map_delete_elem(const void *map, const void *key);
-int bpf_map_get_next_key(const void *map, const void *key, const void *next_key);
+int bpf_map_get_next_key(const void *map, void *key, void *next_key);
 
 // bpf_printk() is just printf()
 #define bpf_printk(fmt, ...)  \

--- a/ebpf.go
+++ b/ebpf.go
@@ -73,6 +73,8 @@ type Map interface {
 	Update(interface{}, interface{}) error
 	Upsert(interface{}, interface{}) error
 	Delete(interface{}) error
+	// Implementation of bpf_map_get_next_key
+	GetNextKey(interface{}) ([]byte, error)
 }
 
 const (

--- a/ebpf.go
+++ b/ebpf.go
@@ -75,6 +75,9 @@ type Map interface {
 	Delete(interface{}) error
 	// Implementation of bpf_map_get_next_key
 	GetNextKey(interface{}) ([]byte, error)
+	GetNextKeyString(interface{}) (string, error)
+	GetNextKeyInt(interface{}) (int, error)
+	GetNextKeyUint64(interface{}) (uint64, error)
 }
 
 const (

--- a/goebpf_mock/mock_map_test.go
+++ b/goebpf_mock/mock_map_test.go
@@ -197,3 +197,35 @@ func TestArrayOfMaps(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, inner.GetFd(), fd)
 }
+
+func TestGetNextKey(t *testing.T) {
+	// Create map
+	m := MockMap{
+		Type:       goebpf.MapTypeHash,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 10,
+	}
+	err := m.Create()
+	assert.NoError(t, err)
+
+	keys := []string{"key1", "key2", "key3"}
+
+	// Insert items into hash map
+	for index, key := range keys {
+		err = m.Insert(key, index)
+		assert.NoError(t, err)
+	}
+	key_to_get := ""
+	for i := len(keys); i >= 0; i-- {
+		k, err := m.GetNextKey(key_to_get)
+		if i == 0 {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		key_to_get = string(k)
+	}
+	assert.NoError(t, err)
+
+}

--- a/goebpf_mock/mock_map_test.go
+++ b/goebpf_mock/mock_map_test.go
@@ -209,7 +209,13 @@ func TestGetNextKeyString(t *testing.T) {
 	err := m.Create()
 	assert.NoError(t, err)
 
-	mapData := map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"}
+	mapData := map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "val3",
+	}
+
+	result := map[string]string{}
 
 	// Insert items into hash map
 	for key, value := range mapData {
@@ -225,8 +231,10 @@ func TestGetNextKeyString(t *testing.T) {
 		val, err := m.LookupString(nextKey)
 		assert.NoError(t, err)
 		assert.Equal(t, mapData[nextKey], string(val))
+		result[nextKey] = val
 		currentKey = nextKey
 	}
+	assert.Equal(t, mapData, result)
 }
 
 func TestGetNextKeyInt(t *testing.T) {
@@ -240,7 +248,13 @@ func TestGetNextKeyInt(t *testing.T) {
 	err := m.Create()
 	assert.NoError(t, err)
 
-	mapData := map[int]int{1234: 4321, 5678: 8765, 9012: 2109}
+	mapData := map[int]int{
+		1234: 4321,
+		5678: 8765,
+		9012: 2109,
+	}
+
+	result := map[int]int{}
 
 	// Insert items into hash map
 	for key, value := range mapData {
@@ -256,6 +270,8 @@ func TestGetNextKeyInt(t *testing.T) {
 		val, err := m.LookupInt(nextKey)
 		assert.NoError(t, err)
 		assert.Equal(t, mapData[nextKey], int(val))
+		result[nextKey] = val
 		currentKey = nextKey
 	}
+	assert.Equal(t, mapData, result)
 }

--- a/itest/map_test.go
+++ b/itest/map_test.go
@@ -454,7 +454,13 @@ func (ts *mapTestSuite) TestGetNextKeyString() {
 	err := m.Create()
 	ts.NoError(err)
 
-	mapData := map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"}
+	mapData := map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "val3",
+	}
+
+	result := map[string]string{}
 
 	// Insert items into hash map
 	for key, value := range mapData {
@@ -470,9 +476,12 @@ func (ts *mapTestSuite) TestGetNextKeyString() {
 		val, err := m.LookupString(nextKey)
 		ts.NoError(err)
 		ts.Equal(mapData[nextKey], string(val))
+		result[nextKey] = val
 		currentKey = nextKey
 	}
+	ts.Equal(mapData, result)
 }
+
 func (ts *mapTestSuite) TestGetNextKeyInt() {
 	// Create map
 	m := &goebpf.EbpfMap{
@@ -484,7 +493,13 @@ func (ts *mapTestSuite) TestGetNextKeyInt() {
 	err := m.Create()
 	ts.NoError(err)
 
-	mapData := map[int]int{1234: 4321, 5678: 8765, 9012: 2109}
+	mapData := map[int]int{
+		1234: 4321,
+		5678: 8765,
+		9012: 2109,
+	}
+
+	result := map[int]int{}
 
 	// Insert items into hash map
 	for key, value := range mapData {
@@ -500,9 +515,10 @@ func (ts *mapTestSuite) TestGetNextKeyInt() {
 		val, err := m.LookupInt(nextKey)
 		ts.NoError(err)
 		ts.Equal(mapData[nextKey], int(val))
+		result[nextKey] = val
 		currentKey = nextKey
 	}
-
+	ts.Equal(mapData, result)
 }
 
 // Run suite

--- a/itest/map_test.go
+++ b/itest/map_test.go
@@ -443,6 +443,36 @@ func (ts *mapTestSuite) TestMapFromExistingByFd() {
 	ts.Equal(m1, m2)
 }
 
+func (ts *mapTestSuite) TestGetNextKey() {
+	// Create map
+	m := &goebpf.EbpfMap{
+		Type:       goebpf.MapTypeHash,
+		KeySize:    8,
+		ValueSize:  8,
+		MaxEntries: 10,
+	}
+	err := m.Create()
+	ts.NoError(err)
+
+	keys := []string{"key1", "key2", "key3"}
+
+	// Insert items into hash map
+	for index, key := range keys {
+		err = m.Insert(key, index)
+		ts.NoError(err)
+	}
+	key_to_get := ""
+	for index, k := range keys {
+		_, err := m.GetNextKey(key_to_get)
+		if index+1 == len(keys) {
+			ts.Error(err)
+		}
+		key_to_get = string(k)
+	}
+	ts.NoError(err)
+
+}
+
 // Run suite
 func TestMapSuite(t *testing.T) {
 	suite.Run(t, new(mapTestSuite))

--- a/map.go
+++ b/map.go
@@ -734,7 +734,7 @@ func (m *EbpfMap) GetNextKey(ikey interface{}) ([]byte, error) {
 			NullTerminatedStringToString(logBuf[:]))
 	}
 
-	return val, nil
+	return nextkey, nil
 }
 
 // GetFd returns fd (file descriptor) of eBPF map

--- a/map.go
+++ b/map.go
@@ -737,6 +737,8 @@ func (m *EbpfMap) GetNextKey(ikey interface{}) ([]byte, error) {
 	return nextKey, nil
 }
 
+// GetNextKeyString looks up next key in the map and returns it
+// as a golang string.
 func (m *EbpfMap) GetNextKeyString(ikey interface{}) (string, error) {
 	nextKey, err := m.GetNextKey(ikey)
 	if err != nil {
@@ -745,11 +747,15 @@ func (m *EbpfMap) GetNextKeyString(ikey interface{}) (string, error) {
 	return NullTerminatedStringToString(nextKey), nil
 }
 
+// GetNextKeyInt looks up next key in the map and returns it
+// as int.
 func (m *EbpfMap) GetNextKeyInt(ikey interface{}) (int, error) {
 	nextKey, err := m.GetNextKeyUint64(ikey)
 	return int(nextKey), err
 }
 
+// GetNextKeyUint64 looks up next key in the map and returns it
+// as uint64.
 func (m *EbpfMap) GetNextKeyUint64(ikey interface{}) (uint64, error) {
 	if m.KeySize > 8 {
 		return 0, errors.New("Value is too large to fit int")


### PR DESCRIPTION
this implements the bpf_map_get_next_key for the library. 

- added the required interfaces and prototypes in bpf_helpers.h,
- created the cgo function and the go method (GetNextKey) for type EbpfMap to use the cgo function
- added tests under itest/map_test.go

edit: 
test results
```
=== RUN   TestMapSuite
=== RUN   TestMapSuite/TestArrayOfMaps
=== RUN   TestMapSuite/TestGetNextKey <<
=== RUN   TestMapSuite/TestHashOfMaps
=== RUN   TestMapSuite/TestMapArrayInt
=== RUN   TestMapSuite/TestMapArrayInt16
=== RUN   TestMapSuite/TestMapArrayUInt64
=== RUN   TestMapSuite/TestMapDoubleClose
=== RUN   TestMapSuite/TestMapFromExistingByFd
=== RUN   TestMapSuite/TestMapHash
=== RUN   TestMapSuite/TestMapLPMTrieIPv4
=== RUN   TestMapSuite/TestMapLPMTrieIPv6
=== RUN   TestMapSuite/TestMapPersistent
=== RUN   TestMapSuite/TestMapProgArray
--- PASS: TestMapSuite (0.13s)
    --- PASS: TestMapSuite/TestArrayOfMaps (0.05s)
    --- PASS: TestMapSuite/TestGetNextKey (0.00s) <<
    --- PASS: TestMapSuite/TestHashOfMaps (0.06s)
    --- PASS: TestMapSuite/TestMapArrayInt (0.00s)
    --- PASS: TestMapSuite/TestMapArrayInt16 (0.00s)
    --- PASS: TestMapSuite/TestMapArrayUInt64 (0.00s)
    --- PASS: TestMapSuite/TestMapDoubleClose (0.00s)
    --- PASS: TestMapSuite/TestMapFromExistingByFd (0.01s)
    --- PASS: TestMapSuite/TestMapHash (0.01s)
    --- PASS: TestMapSuite/TestMapLPMTrieIPv4 (0.00s)
    --- PASS: TestMapSuite/TestMapLPMTrieIPv6 (0.00s)
    --- PASS: TestMapSuite/TestMapPersistent (0.00s)
    --- PASS: TestMapSuite/TestMapProgArray (0.00s)
```