### PR TITLE
removing get_next_key function from kernel-side code

### DIFF
--- a/bpf_helpers.h
+++ b/bpf_helpers.h
@@ -243,7 +243,6 @@ struct bpf_sysctl {
      FN(map_lookup_elem),           \
      FN(map_update_elem),           \
      FN(map_delete_elem),           \
-     FN(map_get_next_key),          \
      FN(probe_read),                \
      FN(ktime_get_ns),              \
      FN(trace_printk),              \
@@ -383,11 +382,6 @@ static int (*bpf_map_update_elem)(const void *map, const void *key,
 // Return: 0 on success or negative error
 static int (*bpf_map_delete_elem)(const void *map, void *key) = (void *)  // NOLINT
     BPF_FUNC_map_delete_elem;
-
-// Get next key gets the next key in the map.
-// Return: 0 on success or negative on error
-static int (*bpf_map_get_next_key)(const void *map, const void *key, const void *next_key) = (void *)  // NOLINT
-    BPF_FUNC_map_get_next_key;
 
 static int (*bpf_probe_read)(void *dst, __u64 size, const void *unsafe_ptr) = (void *) // NOLINT
     BPF_FUNC_probe_read;
@@ -817,7 +811,6 @@ void *bpf_map_lookup_elem(const void *map, const void *key);
 int bpf_map_update_elem(const void *map, const void *key, const void *value,
                         __u64 flags);
 int bpf_map_delete_elem(const void *map, const void *key);
-int bpf_map_get_next_key(const void *map, void *key, void *next_key);
 
 // bpf_printk() is just printf()
 #define bpf_printk(fmt, ...)  \


### PR DESCRIPTION
this removes get_next_key function from kernel code (bpf_helpers.h), as this functionality is supposed to be used only in userland code. 

```
src/goebpf/itest# make test
././itest_test -test.v
=== RUN   TestKprobeSuite
=== RUN   TestKprobeSuite/TestElfLoad
=== RUN   TestKprobeSuite/TestKprobeEvents
--- PASS: TestKprobeSuite (0.51s)
    --- PASS: TestKprobeSuite/TestElfLoad (0.29s)
    --- PASS: TestKprobeSuite/TestKprobeEvents (0.23s)
=== RUN   TestMapSuite
=== RUN   TestMapSuite/TestArrayOfMaps
=== RUN   TestMapSuite/TestGetNextKeyInt
=== RUN   TestMapSuite/TestGetNextKeyString
=== RUN   TestMapSuite/TestHashOfMaps
=== RUN   TestMapSuite/TestMapArrayInt
=== RUN   TestMapSuite/TestMapArrayInt16
=== RUN   TestMapSuite/TestMapArrayUInt64
=== RUN   TestMapSuite/TestMapDoubleClose
=== RUN   TestMapSuite/TestMapFromExistingByFd
=== RUN   TestMapSuite/TestMapHash
=== RUN   TestMapSuite/TestMapLPMTrieIPv4
=== RUN   TestMapSuite/TestMapLPMTrieIPv6
=== RUN   TestMapSuite/TestMapPersistent
=== RUN   TestMapSuite/TestMapProgArray
--- PASS: TestMapSuite (0.21s)
    --- PASS: TestMapSuite/TestArrayOfMaps (0.11s)
    --- PASS: TestMapSuite/TestGetNextKeyInt (0.00s)
    --- PASS: TestMapSuite/TestGetNextKeyString (0.00s)
    --- PASS: TestMapSuite/TestHashOfMaps (0.10s)
    --- PASS: TestMapSuite/TestMapArrayInt (0.00s)
    --- PASS: TestMapSuite/TestMapArrayInt16 (0.00s)
    --- PASS: TestMapSuite/TestMapArrayUInt64 (0.00s)
    --- PASS: TestMapSuite/TestMapDoubleClose (0.00s)
    --- PASS: TestMapSuite/TestMapFromExistingByFd (0.00s)
    --- PASS: TestMapSuite/TestMapHash (0.00s)
    --- PASS: TestMapSuite/TestMapLPMTrieIPv4 (0.00s)
    --- PASS: TestMapSuite/TestMapLPMTrieIPv6 (0.00s)
    --- PASS: TestMapSuite/TestMapPersistent (0.00s)
    --- PASS: TestMapSuite/TestMapProgArray (0.00s)
=== RUN   TestPerfEvents
--- PASS: TestPerfEvents (0.01s)
=== RUN   TestGetNumOfPossibleCpus
--- PASS: TestGetNumOfPossibleCpus (0.00s)
=== RUN   TestXdpSuite
=== RUN   TestXdpSuite/TestElfLoad
=== RUN   TestXdpSuite/TestProgramInfo
--- PASS: TestXdpSuite (0.03s)
    --- PASS: TestXdpSuite/TestElfLoad (0.03s)
    --- PASS: TestXdpSuite/TestProgramInfo (0.00s)
PASS
```

https://travis-ci.org/github/dropbox/goebpf/builds/728180572