### PR TITLE
[tc-bpf] add support for tc-bpf program types

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A nice and convenient way to work with `eBPF` programs / perf events from Go.
     - `SocketFilter`
     - `XDP`
     - `Kprobe` / `Kretprobe`
+    - `tc-cls` / `tc-act`
 - Perf Events
 
 Support for other program types / features can be added in future.

--- a/bpf_helpers.h
+++ b/bpf_helpers.h
@@ -81,6 +81,30 @@ struct bpf_map_def {
 #define BPF_MAP_OFFSET_PERSISTENT offsetof(struct bpf_map_def, persistent_path)
 #define BPF_MAP_OFFSET_INNER_MAP offsetof(struct bpf_map_def, inner_map_def)
 
+/* Generic BPF return codes which all BPF program types may support.
+ * The values are binary compatible with their TC_ACT_* counter-part to
+ * provide backwards compatibility with existing SCHED_CLS and SCHED_ACT
+ * programs.
+ *
+ * XDP is handled seprately, see XDP_*.
+ */
+enum bpf_ret_code {
+  BPF_OK = 0,
+  /* 1 reserved */
+  BPF_DROP = 2,
+  /* 3-6 reserved */
+  BPF_REDIRECT = 7,
+  /* >127 are reserved for prog type specific return codes.
+  *
+  * BPF_LWT_REROUTE: used by BPF_PROG_TYPE_LWT_IN and
+  *    BPF_PROG_TYPE_LWT_XMIT to indicate that skb had been
+  *    changed and should be routed based on its new L3 header.
+  *    (This is an L3 redirect, as opposed to L2 redirect
+  *    represented by BPF_REDIRECT above).
+  */
+  BPF_LWT_REROUTE = 128,
+};
+
 // XDP related constants
 enum xdp_action {
   XDP_ABORTED = 0,
@@ -457,6 +481,9 @@ static int (*bpf_perf_event_output)(void *ctx, void *map, __u64 index, void *dat
 
 static int (*bpf_skb_load_bytes)(void *ctx, int offset, void *to, __u32 len) = (void*) // NOLINT
      BPF_FUNC_skb_load_bytes;
+
+static int (*bpf_skb_store_bytes)(void *ctx, int offset, const void *from, __u32 len, __u64 flags) = (void *) // NOLINT
+     BPF_FUNC_skb_store_bytes;
 
 static int (*bpf_perf_event_read_value)(void *map, __u64 flags, void *buf, __u32 buf_size) = (void*) // NOLINT
      BPF_FUNC_perf_event_read_value;

--- a/itest/Makefile
+++ b/itest/Makefile
@@ -14,6 +14,8 @@ EBPF_XDP_SOURCE := ebpf_prog/xdp1.c
 EBPF_XDP_BINARY := ebpf_prog/xdp1.elf
 EBPF_KPROBE_SOURCE := ebpf_prog/kprobe1.c
 EBPF_KPROBE_BINARY := ebpf_prog/kprobe1.elf
+EBPF_TC_SOURCE := ebpf_prog/tc1.c
+EBPF_TC_BINARY := ebpf_prog/tc1.elf
 
 EUID := $(shell id -u -r)
 
@@ -25,11 +27,14 @@ $(EBPF_XDP_BINARY): $(EBPF_XDP_SOURCE)
 $(EBPF_KPROBE_BINARY): $(EBPF_KPROBE_SOURCE)
 	clang -I.. -O2 -target bpf -c $^  -o $@
 
+$(EBPF_TC_BINARY): $(EBPF_TC_SOURCE)
+	clang -I.. -O2 -target bpf -c $^  -o $@
+
 $(TEST_BINARY): $(TEST_SOURCE)
 	$(GOTEST) -c -v -o $@
 
 build_test: $(TEST_BINARY)
-build_bpf: $(EBPF_XDP_BINARY) $(EBPF_KPROBE_BINARY)
+build_bpf: $(EBPF_XDP_BINARY) $(EBPF_KPROBE_BINARY) $(EBPF_TC_BINARY)
 
 check_root:
 ifneq ($(EUID),0)
@@ -42,6 +47,7 @@ clean:
 	rm -f $(TEST_BINARY)
 	rm -f $(EBPF_XDP_BINARY)
 	rm -f $(EBPF_KPROBE_BINARY)
+	rm -f $(EBPF_TC_BINARY)
 
 test: check_root build_bpf build_test
 	@ulimit -l unlimited

--- a/itest/ebpf_prog/tc1.c
+++ b/itest/ebpf_prog/tc1.c
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Dropbox, Inc.
+// Full license can be found in the LICENSE file.
+
+// Set of simple TC programs for eBPF library integration tests
+
+#include "bpf_helpers.h"
+
+
+SEC("tc_cls")
+int tc1(struct __sk_buff *skb)
+{
+  return BPF_OK;
+}
+
+SEC("tc_act")
+int tc2(struct __sk_buff *skb)
+{
+  return BPF_DROP;
+}
+
+SEC("tc_act")
+int tc3(struct __sk_buff *skb)
+{
+  return bpf_redirect(1, 0);
+}
+
+char _license[] SEC("license") = "GPL";

--- a/itest/tc_test.go
+++ b/itest/tc_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2019 Dropbox, Inc.
+// Full license can be found in the LICENSE file.
+
+package itest
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dropbox/goebpf"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	tcProgramFilename = "ebpf_prog/tc1.elf"
+)
+
+type tcTestSuite struct {
+	suite.Suite
+	programFilename string
+	programsCount   int
+}
+
+// Basic sanity test of BPF core functionality like
+// ReadElf, create maps, load / attach programs
+func (ts *tcTestSuite) TestElfLoad() {
+	// This compile ELF file contains 2 BPF(TC type) programs
+	eb := goebpf.NewDefaultEbpfSystem()
+	err := eb.LoadElf(ts.programFilename)
+	ts.NoError(err)
+	if err != nil {
+		// ELF read error.
+		ts.FailNowf("Unable to read %s", ts.programFilename)
+	}
+
+	// There should be 0 BPF maps recognized by loader
+	maps := eb.GetMaps()
+	ts.Require().Equal(0, len(maps))
+
+	// Non existing map
+	ts.Nil(eb.GetMapByName("something"))
+
+	// Also there should few TC eBPF programs recognized
+	ts.Require().Equal(ts.programsCount, len(eb.GetPrograms()))
+
+	// Check loaded programs and try to pin them
+	tc1 := eb.GetProgramByName("tc1")
+	tc1.Load()
+	path := bpfPath + "/tc1_pin_test"
+	err = tc1.Pin(path)
+	ts.NoError(err)
+	ts.FileExists(path)
+	os.Remove(path)
+	ts.Equal(goebpf.ProgramTypeSchedCls, tc1.GetType())
+
+	// Check loaded programs and try to pin them
+	tc2 := eb.GetProgramByName("tc2")
+	tc2.Load()
+	path = bpfPath + "/tc2_pin_test"
+	err = tc2.Pin(path)
+	ts.NoError(err)
+	ts.FileExists(path)
+	os.Remove(path)
+	ts.Equal(goebpf.ProgramTypeSchedAct, tc2.GetType())
+
+	// Check loaded programs and try to pin them
+	tc3 := eb.GetProgramByName("tc3")
+	tc3.Load()
+	path = bpfPath + "/tc3_pin_test"
+	err = tc3.Pin(path)
+	ts.NoError(err)
+	ts.FileExists(path)
+	os.Remove(path)
+	ts.Equal(goebpf.ProgramTypeSchedAct, tc3.GetType())
+
+	// Non existing program
+	ts.Nil(eb.GetProgramByName("something"))
+
+	//Run attach and detach, they shouldn't fail as these methods are not implemented for TC
+	err = tc1.Attach(0)
+	ts.Error(err)
+	err = tc1.Detach()
+	ts.Error(err)
+	err = tc2.Attach(0)
+	ts.Error(err)
+	err = tc2.Detach()
+	ts.Error(err)
+	err = tc3.Attach(0)
+	ts.Error(err)
+	err = tc3.Detach()
+	ts.Error(err)
+
+	// Unload programs (not required for real use case)
+	for _, program := range eb.GetPrograms() {
+		err = program.Close()
+		ts.NoError(err)
+	}
+
+	// Negative: close already closed program
+	err = tc1.Close()
+	ts.Error(err)
+
+}
+
+func (ts *tcTestSuite) TestProgramInfo() {
+	// Load test program, don't attach (not required to get info)
+	eb := goebpf.NewDefaultEbpfSystem()
+	err := eb.LoadElf(ts.programFilename)
+	ts.Require().NoError(err)
+	prog := eb.GetProgramByName("tc1")
+	err = prog.Load()
+	ts.Require().NoError(err)
+
+	// Get program info by FD (NOT ID, since this program is ours)
+	info, err := goebpf.GetProgramInfoByFd(prog.GetFd())
+	ts.NoError(err)
+
+	// Check base info
+	ts.Equal(prog.GetName(), info.Name)
+	ts.Equal(prog.GetFd(), info.Fd)
+	ts.Equal(goebpf.ProgramTypeSchedCls, info.Type)
+	// Check loaded time
+	now := time.Now()
+	ts.True(now.Sub(info.LoadTime) < time.Second*10)
+
+}
+
+// Run suite
+func TestTcSuite(t *testing.T) {
+	suite.Run(t, &tcTestSuite{
+		programFilename: tcProgramFilename,
+		programsCount:   3,
+	})
+}

--- a/loader.go
+++ b/loader.go
@@ -38,6 +38,8 @@ var sectionNameToProgramType = map[string]programCreator{
 	"socket_filter": newSocketFilterProgram,
 	"kprobe":        newKprobeProgram,
 	"kretprobe":     newKretprobeProgram,
+	"tc_cls":        newTcSchedClsProgram,
+	"tc_act":        newTcSchedActProgram,
 }
 
 // BPF instruction //

--- a/program_tc.go
+++ b/program_tc.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Dropbox, Inc.
+// Full license can be found in the LICENSE file.
+
+package goebpf
+
+import (
+	"fmt"
+)
+
+// TC eBPF program (implements Program interface)
+type tcProgram struct {
+	BaseProgram
+	progType TcProgramType
+}
+
+// TcProgramType selects a way how TC program will be attached
+// it can either be BPF_PROG_TYPE_SCHED_CLS or BPF_PROG_TYPE_SCHED_ACT
+type TcProgramType int
+
+const (
+	// TcProgramTypeCls is the `tc filter program type
+	TcProgramTypeCls TcProgramType = iota
+	// TcProgramTypeAct is the `tc action`program type
+	TcProgramTypeAct
+)
+
+func (t TcProgramType) String() string {
+	switch t {
+	case TcProgramTypeCls:
+		return "tc_cls"
+	case TcProgramTypeAct:
+		return "tc_act"
+	default:
+		return "tc_unknown"
+	}
+}
+
+func newTcSchedClsProgram(bp BaseProgram) Program {
+	bp.programType = ProgramTypeSchedCls
+	return &tcProgram{
+		BaseProgram: bp,
+		progType:    TcProgramTypeCls,
+	}
+}
+
+func newTcSchedActProgram(bp BaseProgram) Program {
+	bp.programType = ProgramTypeSchedAct
+	return &tcProgram{
+		BaseProgram: bp,
+		progType:    TcProgramTypeAct,
+	}
+}
+
+func (p *tcProgram) Attach(data interface{}) error {
+	return fmt.Errorf("Attach() not implemented for program type %s", p.BaseProgram.GetType())
+}
+
+func (p *tcProgram) Detach() error {
+	return fmt.Errorf("Detach() not implemented for program type %s", p.BaseProgram.GetType())
+}


### PR DESCRIPTION
this PR adds support for loading TC programs (sched_cls and sched_act)
also added missing prototype for bpf_skb_store_bytes helper, as well as the return codes used by this program.

i decided not to add TC_ACT_* in here, as they can be imported from `include/uapi/linux/pkt_cls.h`, and the BPF_* ones can be used for the basic use cases. 

not sure about the Attach() and Detach() methods, though - i couldn't find a good way of doing that. any ideas would be very much welcome!

without these two methods, the programs can still be loaded and pinned to bpffs using this library, and attached to the desired classifier/action using iproute2 `tc` command, by referencing the pinned file.

submitting this as a draft as i'd like to get some input on how to implement the Attach() and Detach() functions.

edit: after thinking on the attach and detach functions, i decided to leave it as it is. it can still be used to load and pin the program, and user can simply use iproute2 (or any other netlink library) to attach the program to the classifier/action

sample code:
```
#define DEBUG
SEC("tc_act")
int tc1(struct __sk_buff *skb) {
    bpf_printk("TC1! %d\n", skb->ifindex);
    return 1;
}   

SEC("tc_cls")
int tc2(struct __sk_buff *skb) {
    bpf_printk("TC2! %d\n", skb->ifindex);
    return 1;
}   

char _license[] SEC("license") = "GPL";
```

go code:
```
func main() {
	system := goebpf.NewDefaultEbpfSystem()
	if err := system.LoadElf(ebpfProgFile); err != nil {
		panic(err)
	}
	prog1 := system.GetProgramByName("tc1")
	if prog1 == nil {
		panic("failed to load program tc1")
	}
	prog2 := system.GetProgramByName("tc2")
	if prog2 == nil {
		panic("failed to load program tc2")
	}
	err := prog1.Load()
	if err != nil {
		panic(err)
	}
	err = prog2.Load()
	if err != nil {
		panic(err)
	}
	err = prog1.Pin("/sys/fs/bpf/tc1")
	if err != nil {
		panic(err)
	}
	err = prog2.Pin("/sys/fs/bpf/tc2")
	if err != nil {
		panic(err)
	}
```


```
# ./tc-bpf
# ls -al /sys/fs/bpf/tc*
-rw------- 1 root root 0 May 24 19:50 /sys/fs/bpf/tc1
-rw------- 1 root root 0 May 24 19:50 /sys/fs/bpf/tc2
# tc filter add dev eth1 ingress bpf direct-action fd /sys/fs/bpf/tc2
# tc filter show dev eth1 ingress
...
filter protocol all pref 49152 bpf chain 0
filter protocol all pref 49152 bpf chain 0 handle 0x1 tc2:[*fsobj] direct-action not_in_hw id 38 tag 0fc79a6db0f3637a jited
# cat /sys/kernel/debug/tracing/trace
# tracer: nop
#
# entries-in-buffer/entries-written: 150/2329   #P:2
#
#                                _-----=> irqs-off
#                               / _----=> need-resched
#                              | / _---=> hardirq/softirq
#                              || / _--=> preempt-depth
#                              ||| /     delay
#           TASK-PID     CPU#  ||||   TIMESTAMP  FUNCTION
#              | |         |   ||||      |         |
          <idle>-0       [000] d.s. 459676.240848: bpf_trace_printk: TC2! 4

          <idle>-0       [001] d.s. 459721.704846: bpf_trace_printk: TC2!
# tc qdisc add dev eth2 clsact
# tc qdisc show dev eth2
qdisc mq 0: root
qdisc pfifo_fast 0: parent :2 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
qdisc pfifo_fast 0: parent :1 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
qdisc clsact ffff: parent ffff:fff1
# tc filter add dev eth2 egress  bpf direct-action fd /sys/fs/bpf/tc2
# tc filter show dev eth2 egress
filter protocol all pref 49152 bpf chain 0
filter protocol all pref 49152 bpf chain 0 handle 0x1 tc2:[*fsobj] direct-action not_in_hw id 38 tag 0fc79a6db0f3637a jited
# tc actions add  bpf fd /sys/fs/bpf/tc1
# tc actions list action bpf
total acts 1

	action order 0: bpf tc1:[*fsobj] id 37 tag 1688c144d5570f72 jited default-action pipe
	 index 1 ref 1 bind 0
# tc qdisc add dev eth1 handle ffff: ingress
#  tc filter add dev eth1  parent ffff: protocol ip prio 420  u32 match ip protocol 17 0xff   action bpf fd /sys/fs/bpf/tc1
# tc filter show dev eth1 ingress
filter parent ffff: protocol ip pref 420 u32 chain 0
filter parent ffff: protocol ip pref 420 u32 chain 0 fh 800: ht divisor 1
filter parent ffff: protocol ip pref 420 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 terminal flowid ??? not_in_hw
  match 00110000/00ff0000 at 8
	action order 1: bpf tc1:[*fsobj] id 37 tag 1688c144d5570f72 jited default-action pipe
	 index 5 ref 1 bind 1
# cat /sys/kernel/debug/tracing/trace
# tracer: nop
#
# entries-in-buffer/entries-written: 25/25   #P:2
#
#                                _-----=> irqs-off
#                               / _----=> need-resched
#                              | / _---=> hardirq/softirq
#                              || / _--=> preempt-depth
#                              ||| /     delay
#           TASK-PID     CPU#  ||||   TIMESTAMP  FUNCTION
#              | |         |   ||||      |         |
          <idle>-0       [001] dNs. 461239.357747: bpf_trace_printk: TC1! 3

          <idle>-0       [001] dNs. 461239.357750: bpf_trace_printk: TC1! 3

          <idle>-0       [001] dNs. 461239.357751: bpf_trace_printk: TC1! 3
```

