### PR TITLE
deprecate go1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: true
 
 go:
   - "tip"
+  - "1.15.x"
   - "1.12.x"
   - "1.11.x"
-  - "1.10.x"
 
 before_install:
   - sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A nice and convenient way to work with `eBPF` programs / perf events from Go.
 
 ## Requirements
-- Go 1.10+
+- Go 1.11+
 - Linux Kernel 4.15+
 
 ## Supported eBPF features


### PR DESCRIPTION
Subj,

`netlink ` library is no longer compatible with `go1.10`.
Let's get rid of it `go1.10`