### PR TITLE
[bpf_get_next_key] add support for fetching the first key in map

### DIFF
--- a/goebpf_mock/mock_map.go
+++ b/goebpf_mock/mock_map.go
@@ -103,6 +103,9 @@ static void *bpf_find_next_item_by_key(struct __create_map_def *map, const void 
 	struct bpf_map_data_head *head = (struct bpf_map_data_head*) &map->map_data;
 	struct bpf_map_item *item = NULL;
 	SLIST_FOREACH(item, head, next) {
+		if (key == NULL) {
+			return SLIST_FIRST(head);
+		}
 		if (memcmp(key, item->key, map->map_def->key_size) == 0) {
 			struct bpf_map_item *nextitem = SLIST_NEXT(item, next);
 			// if next key points to the head (first item), return NULL
@@ -558,9 +561,15 @@ func (m *MockMap) GetNextKey(ikey interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	var k *byte
+	if key != nil {
+		k = &key[0]
+	}
+
 	var nextKey = make([]byte, m.KeySize)
 	res := C.bpf_map_get_next_key(m.fd,
-		unsafe.Pointer(&key[0]),
+		unsafe.Pointer(k),
 		unsafe.Pointer(&nextKey[0]),
 	)
 

--- a/goebpf_mock/mock_map_test.go
+++ b/goebpf_mock/mock_map_test.go
@@ -213,6 +213,7 @@ func TestGetNextKeyString(t *testing.T) {
 		"key1": "val1",
 		"key2": "val2",
 		"key3": "val3",
+		"":     "val4",
 	}
 
 	result := map[string]string{}
@@ -222,16 +223,17 @@ func TestGetNextKeyString(t *testing.T) {
 		err = m.Insert(key, value)
 		assert.NoError(t, err)
 	}
-	var currentKey string
+	currentKey, err := m.GetNextKeyString(nil)
+	assert.NoError(t, err)
 	for {
+		val, err := m.LookupString(currentKey)
+		assert.NoError(t, err)
+		assert.Equal(t, mapData[currentKey], string(val))
+		result[currentKey] = val
 		nextKey, err := m.GetNextKeyString(currentKey)
 		if err != nil {
 			break
 		}
-		val, err := m.LookupString(nextKey)
-		assert.NoError(t, err)
-		assert.Equal(t, mapData[nextKey], string(val))
-		result[nextKey] = val
 		currentKey = nextKey
 	}
 	assert.Equal(t, mapData, result)
@@ -252,6 +254,7 @@ func TestGetNextKeyInt(t *testing.T) {
 		1234: 4321,
 		5678: 8765,
 		9012: 2109,
+		0:    123,
 	}
 
 	result := map[int]int{}
@@ -261,16 +264,17 @@ func TestGetNextKeyInt(t *testing.T) {
 		err = m.Insert(key, value)
 		assert.NoError(t, err)
 	}
-	var currentKey int
+	currentKey, err := m.GetNextKeyInt(nil)
+	assert.NoError(t, err)
 	for {
+		val, err := m.LookupInt(currentKey)
+		assert.NoError(t, err)
+		assert.Equal(t, mapData[currentKey], int(val))
+		result[currentKey] = val
 		nextKey, err := m.GetNextKeyInt(currentKey)
 		if err != nil {
 			break
 		}
-		val, err := m.LookupInt(nextKey)
-		assert.NoError(t, err)
-		assert.Equal(t, mapData[nextKey], int(val))
-		result[nextKey] = val
 		currentKey = nextKey
 	}
 	assert.Equal(t, mapData, result)

--- a/itest/map_test.go
+++ b/itest/map_test.go
@@ -459,6 +459,7 @@ func (ts *mapTestSuite) TestGetNextKeyString() {
 		"key1": "val1",
 		"key2": "val2",
 		"key3": "val3",
+		"":     "val4",
 	}
 
 	result := map[string]string{}
@@ -468,16 +469,17 @@ func (ts *mapTestSuite) TestGetNextKeyString() {
 		err = m.Insert(key, value)
 		ts.NoError(err)
 	}
-	var currentKey string
+	currentKey, err := m.GetNextKeyString(nil)
+	ts.NoError(err)
 	for {
+		val, err := m.LookupString(currentKey)
+		ts.NoError(err)
+		ts.Equal(mapData[currentKey], string(val))
+		result[currentKey] = val
 		nextKey, err := m.GetNextKeyString(currentKey)
 		if err != nil {
 			break
 		}
-		val, err := m.LookupString(nextKey)
-		ts.NoError(err)
-		ts.Equal(mapData[nextKey], string(val))
-		result[nextKey] = val
 		currentKey = nextKey
 	}
 	ts.Equal(mapData, result)
@@ -498,6 +500,7 @@ func (ts *mapTestSuite) TestGetNextKeyInt() {
 		1234: 4321,
 		5678: 8765,
 		9012: 2109,
+		0:    1234,
 	}
 
 	result := map[int]int{}
@@ -507,16 +510,17 @@ func (ts *mapTestSuite) TestGetNextKeyInt() {
 		err = m.Insert(key, value)
 		ts.NoError(err)
 	}
-	var currentKey int
+	currentKey, err := m.GetNextKeyInt(nil)
+	ts.NoError(err)
 	for {
+		val, err := m.LookupInt(currentKey)
+		ts.NoError(err)
+		ts.Equal(mapData[currentKey], int(val))
+		result[currentKey] = val
 		nextKey, err := m.GetNextKeyInt(currentKey)
 		if err != nil {
 			break
 		}
-		val, err := m.LookupInt(nextKey)
-		ts.NoError(err)
-		ts.Equal(mapData[nextKey], int(val))
-		result[nextKey] = val
 		currentKey = nextKey
 	}
 	ts.Equal(mapData, result)

--- a/utils.go
+++ b/utils.go
@@ -401,6 +401,8 @@ func KeyValueToBytes(ival interface{}, size int) ([]byte, error) {
 	var res = make([]byte, size)
 
 	switch val := ival.(type) {
+	case nil:
+		return nil, nil
 	case int:
 		// Flexible integer, little endian
 		remainder := uint64(val)


### PR DESCRIPTION
build showing the issue in the tests:
https://app.travis-ci.com/github/dropbox/goebpf/jobs/575825851

if we use the uninitialized value as the first key, it ends up skipping one of the keys.