### PR TITLE
Implement Attach/Detach for TcProgramTypeCls, add packet_counter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A nice and convenient way to work with `eBPF` programs / perf events from Go.
     - `SocketFilter`
     - `XDP`
     - `Kprobe` / `Kretprobe`
-    - `tc-cls` / `tc-act`
+    - `tc-cls` (`tc-act` is partially implemented, currently)
 - Perf Events
 
 Support for other program types / features can be added in future.

--- a/examples/tc/packet_counter/Makefile
+++ b/examples/tc/packet_counter/Makefile
@@ -1,0 +1,34 @@
+# Copyright (c) 2019 Dropbox, Inc.
+# Full license can be found in the LICENSE file.
+
+GOCMD := go
+GOBUILD := $(GOCMD) build
+GOCLEAN := $(GOCMD) clean
+CLANG := clang
+CLANG_INCLUDE := -I../../..
+
+GO_SOURCE := main.go
+GO_BINARY := main
+
+EBPF_HEADERS := $(wildcard ebpf_prog/*.h)
+EBPF_SOURCE := $(wildcard ebpf_prog/*.c)
+EBPF_BINARY := ebpf_prog/tc.elf
+
+all: build_bpf build_go
+
+build_bpf: $(EBPF_BINARY)
+
+build_go: $(GO_BINARY)
+
+clean:
+	$(GOCLEAN)
+	rm -f $(GO_BINARY)
+	rm -f $(EBPF_BINARY)
+
+$(EBPF_SOURCE): $(EBPF_HEADERS)
+
+$(EBPF_BINARY): $(EBPF_SOURCE)
+	$(CLANG) $(CLANG_INCLUDE) -O2 -target bpf -DGO_EBPF -c $^  -o $@
+
+$(GO_BINARY): $(GO_SOURCE)
+	$(GOBUILD) -v -o $@

--- a/examples/tc/packet_counter/ebpf_prog/tc.c
+++ b/examples/tc/packet_counter/ebpf_prog/tc.c
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Dropbox, Inc.
+// Based on the example by Konstantin Belyalov:
+// https://github.com/dropbox/goebpf/blob/master/examples/xdp/packet_counter/ebpf_prog/xdp.c
+#include "tc.h"
+
+// eBPF map to store IP metric counters
+BPF_MAP_DEF(metrics, BPF_MAP_TYPE_PERCPU_ARRAY, sizeof(__u32), sizeof(__u64), 255);
+
+static __always_inline int account_data(struct __sk_buff *skb, __u32 hashidx)
+{
+  void *data_end = (void *)(long)skb->data_end;
+  void *data = (void *)(long)skb->data;
+  // Only IPv4 supported for now
+  struct ethhdr *ether = data;
+  if (data + sizeof(*ether) > data_end) {
+    return TC_ACT_OK;
+  }
+  if (ether->h_proto == 0x08U) {  // htons(ETH_P_IP) -> 0x08U
+    data += sizeof(*ether);
+    struct iphdr *ip = data;
+    if (data + sizeof(*ip) > data_end) {
+      return TC_ACT_OK;
+    }
+    if (ip->version != 4) {
+      return TC_ACT_OK;
+    }
+    // Increment packet count
+    __u64 *counter = bpf_map_lookup_elem(&metrics, &hashidx);
+    if (counter) {
+      __sync_fetch_and_add(counter, 1);
+    }
+    // Increment total bytes
+    hashidx |= HASH_FLAG_UNIT_BYTES;
+    counter = bpf_map_lookup_elem(&metrics, &hashidx);
+    if (counter) {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      // byte swap tot_len to LE before adding
+      __sync_fetch_and_add(counter,
+        ((ip->tot_len << 8) & 0xFF00) | (ip->tot_len >> 8));
+#else
+      __sync_fetch_and_add(counter, ip->tot_len);
+#endif
+    }
+  }
+  return TC_ACT_OK;
+}
+// TC program //
+SEC("tc_cls")
+int tc_ingress(struct __sk_buff *skb) {
+  return account_data(skb, HASH_FLAG_DIR_INGRESS);
+}
+SEC("tc_cls")
+int tc_egress(struct __sk_buff *skb) {
+  return account_data(skb, HASH_FLAG_DIR_EGRESS);
+}
+char _license[] SEC("license") = "GPLv2";

--- a/examples/tc/packet_counter/ebpf_prog/tc.h
+++ b/examples/tc/packet_counter/ebpf_prog/tc.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 Dropbox, Inc.
+// Based on the example by Konstantin Belyalov:
+// https://github.com/dropbox/goebpf/blob/master/examples/xdp/packet_counter/ebpf_prog/xdp.c
+
+#ifndef GO_EBPF
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#include <linux/byteorder/little_endian.h>
+#else
+#include <linux/byteorder/big_endian.h>
+#endif
+#endif
+
+#ifdef GO_EBPF
+// if compiling for goebpf, use our local bpf_helpers.h
+#include "bpf_helpers.h"
+#else
+// if compiling to be attached with iproute2
+//   (`tc filter add ... bpf obj tc.o ...`), pull these headers
+// in from the system
+#include <asm/types.h>
+#include <bpf/bpf_helpers.h>
+#include <linux/bpf.h>
+#include <iproute2/bpf_elf.h>
+#include <sys/cdefs.h>
+#endif
+
+#include <linux/pkt_cls.h>
+
+#define HASH_FLAG_DIR_INGRESS  0
+#define HASH_FLAG_DIR_EGRESS   (1 << 0)
+#define HASH_FLAG_UNIT_PACKETS 0
+#define HASH_FLAG_UNIT_BYTES   (1 << 1)
+
+// Ethernet header
+struct ethhdr {
+  __u8 h_dest[6];
+  __u8 h_source[6];
+  __u16 h_proto;
+} __attribute__((packed));
+
+// IPv4 header
+struct iphdr {
+  __u8 ihl : 4;
+  __u8 version : 4;
+  __u8 tos;
+  __u16 tot_len;
+  __u16 id;
+  __u16 frag_off;
+  __u8 ttl;
+  __u8 protocol;
+  __u16 check;
+  __u32 saddr;
+  __u32 daddr;
+} __attribute__((packed));
+
+// BPF_MAP_DEF is outdated in currently shipping linux-api-headers as of
+// 08/2022 :/
+// Latest libbpf requires maps defined in BTF, while goebpf uses the old
+// maps section format, so we support both here.
+#undef BPF_MAP_DEF
+
+#ifdef GO_EBPF
+#define BPF_MAP_DEF(_name, _type, _key_size, _value_size, _max_entries) \
+	struct bpf_map_def SEC("maps") _name = {                            \
+		.map_type = _type,                                              \
+		.key_size = _key_size,                                          \
+		.value_size = _value_size,                                      \
+		.max_entries = _max_entries,                                    \
+	}
+
+#else
+#define BPF_MAP_DEF(_name, _type, _key_size, _value_size, _max_entries) \
+	struct {                                                            \
+		__u32 (*type)[BPF_MAP_TYPE_PERCPU_ARRAY];                       \
+		__u32 (*key_size)[sizeof(__u32)];                               \
+		__u32 (*value_size)[sizeof(__u64)];                             \
+		__u32 (*max_entries)[255];                                      \
+	} _name SEC(".maps");
+#endif

--- a/examples/tc/packet_counter/main.go
+++ b/examples/tc/packet_counter/main.go
@@ -68,10 +68,10 @@ func main() {
 		}
 
 		attachParams := &goebpf.TcAttachParams{
-			Interface:    *iface,
-			Direction:    prog.direction,
-			DirectAction: false,
-			EntryPoint:   prog.name,
+			Interface:      *iface,
+			Direction:      prog.direction,
+			DirectAction:   false,
+			EntryPoint:     prog.name,
 			ClobberIngress: true,
 		}
 

--- a/examples/tc/packet_counter/main.go
+++ b/examples/tc/packet_counter/main.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2019 Dropbox, Inc.
+// Full license can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/dropbox/goebpf"
+)
+
+var iface = flag.String("iface", "", "Interface to bind TC program to")
+var elf = flag.String("elf", "ebpf_prog/tc.elf", "clang/llvm compiled binary file")
+var ingressFunction = flag.String("ingress", "tc_ingress", "Name of tc program (function name) for ingress traffic")
+var egressFunction = flag.String("egress", "tc_egress", "Name of tc program (function name) for egress traffic")
+
+const (
+	HASH_FLAG_DIR_INGRESS  = 0
+	HASH_FLAG_DIR_EGRESS   = (1 << 0)
+	HASH_FLAG_UNIT_PACKETS = 0
+	HASH_FLAG_UNIT_BYTES   = (1 << 1)
+)
+
+func main() {
+	flag.Parse()
+	if *iface == "" {
+		fatalError("-iface is required.")
+	}
+
+	// Create eBPF system / load .ELF files compiled by clang/llvm
+	bpf := goebpf.NewDefaultEbpfSystem()
+	err := bpf.LoadElf(*elf)
+	if err != nil {
+		fatalError("LoadElf() failed: %v", err)
+	}
+	printBpfInfo(bpf)
+
+	// Find metrics eBPF map
+	metrics := bpf.GetMapByName("metrics")
+	if metrics == nil {
+		fatalError("eBPF map 'metrics' not found")
+	}
+
+	// entrypoints are
+	// int tc_ingress(struct __sk_buff *skb)
+	// int tc_egress(struct __sk_buff *skb)
+	var programs = []struct {
+		name      string
+		direction goebpf.TcFlowDirection
+	}{
+		{*ingressFunction, goebpf.TcDirectionIngress},
+		{*egressFunction, goebpf.TcDirectionEgress},
+	}
+	for _, prog := range programs {
+		program := bpf.GetProgramByName(prog.name)
+
+		if program == nil {
+			fatalError("No programs of type 'SchedACT' not found.")
+		}
+
+		err = program.Load()
+		if err != nil {
+			fatalError("program.Load() failed: %v", err)
+		}
+
+		attachParams := &goebpf.TcAttachParams{
+			Interface:    *iface,
+			Direction:    prog.direction,
+			DirectAction: false,
+			EntryPoint:   prog.name,
+			ClobberIngress: true,
+		}
+
+		err = program.Attach(attachParams)
+		defer program.Detach()
+
+		if err != nil {
+			fatalError("Failed to attach %s program: %v", prog.direction.String(), err)
+		}
+	}
+
+	// Add CTRL+C handler
+	ctrlC := make(chan os.Signal, 1)
+	signal.Notify(ctrlC, os.Interrupt)
+
+	// Print stat every second / exit on CTRL+C
+	fmt.Println("TC program successfully loaded and attached. Counters refreshed every second.")
+	fmt.Println()
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			// clear the screen
+			fmt.Print("\x1B[2J")
+			// move cursor to top left of screen
+			fmt.Print("\x1B[1;1H")
+
+			// currently 4 metric slots are used: {tx,rx} {packets,bytes}
+			for i := 0; i < 4; i++ {
+				value, err := metrics.LookupInt(i)
+				if err != nil {
+					fatalError("LookupInt failed: %v", err)
+				}
+				if value > 0 {
+					fmt.Printf("% -20s: %d\n", getMetricName(i), value)
+				}
+			}
+		case <-ctrlC:
+			fmt.Println("\nDetaching program and exit")
+			return
+		}
+	}
+}
+
+func fatalError(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func printBpfInfo(bpf goebpf.System) {
+	fmt.Println("Maps:")
+	for _, item := range bpf.GetMaps() {
+		fmt.Printf("\t%s: %v, Fd %v\n", item.GetName(), item.GetType(), item.GetFd())
+	}
+	fmt.Println("\nPrograms:")
+	for _, prog := range bpf.GetPrograms() {
+		fmt.Printf("\t%s: %v, size %d, license \"%s\"\n",
+			prog.GetName(), prog.GetType(), prog.GetSize(), prog.GetLicense(),
+		)
+
+	}
+	fmt.Println()
+}
+
+func getMetricName(index int) string {
+	unit := "packets"
+	direction := "rx"
+
+	if (index & HASH_FLAG_UNIT_BYTES) > 0 {
+		unit = "bytes"
+	}
+
+	if (index & HASH_FLAG_DIR_EGRESS) > 0 {
+		direction = "tx"
+	}
+
+	return fmt.Sprintf("[idx %d] %s %s", index, direction, unit)
+}

--- a/program_tc.go
+++ b/program_tc.go
@@ -4,24 +4,79 @@
 package goebpf
 
 import (
+	"errors"
 	"fmt"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // TC eBPF program (implements Program interface)
 type tcProgram struct {
 	BaseProgram
-	progType TcProgramType
+	progType  TcProgramType
+	link      netlink.Link
+	direction TcFlowDirection
+	handle    uint32
+}
+
+// Attachment parameters dictating where and how the eBPF program is attached.
+// The current behavior is to attach to the "egress" and "ingress" pseudo-qdiscs
+// created by clsact.
+type TcAttachParams struct {
+	// Name of the network interface to which the program should be atached
+	// i.e. "eth0"
+	Interface string
+
+	// Flow direction, either TcDirectionIngress or TcDirectionEgress
+	Direction TcFlowDirection
+
+	// If true, the eBPF program gets to choose what happens to the packet
+	// through its return value. If false, the packet always continues
+	// through the filter chain, which is preferred for programs that only
+	// log things (i.e. aren't used for altering or classifying traffic).
+	DirectAction bool
+
+	// Name of the symbol (C function) to load from the eBPF program.
+	EntryPoint string
+
+	// Whether to allow clobbering the ingress qdisc. This could interfere with
+	// an existing tc configuration, so tread with caution if enabling this
+	// option.
+	ClobberIngress bool
 }
 
 // TcProgramType selects a way how TC program will be attached
 // it can either be BPF_PROG_TYPE_SCHED_CLS or BPF_PROG_TYPE_SCHED_ACT
 type TcProgramType int
 
+// TcFlowDirection indicates whether the program goes into the egress or ingress
+// side of the clsact pseudo-qdisc. Filters have different parent handles which
+// are also determined by the value of the direction property.
+type TcFlowDirection int
+
 const (
-	// TcProgramTypeCls is the `tc filter program type
+	// TcProgramTypeCls is the `tc filter` program type
 	TcProgramTypeCls TcProgramType = iota
-	// TcProgramTypeAct is the `tc action`program type
+	// TcProgramTypeAct is the `tc action` program type
+	// Please note, support for this is currently not implemented
 	TcProgramTypeAct
+
+	// Handle that must be used by the ingress or clsact qdisc.
+	HANDLE_INGRESS_QDISC uint32 = 0xFFFF0000
+
+	// Lowest handle value that will be used by a filter installed by this
+	// program. Ideally this should not conflict with filters that might be
+	// installed by another script.
+	//
+	// It should be possible to install multiple filters, including in the
+	// same direction, and run them concurrently.
+	HANDLE_FILTER_BASE uint32 = 0x1600
+)
+
+const (
+	TcDirectionIngress TcFlowDirection = iota
+	TcDirectionEgress
 )
 
 func (t TcProgramType) String() string {
@@ -51,10 +106,272 @@ func newTcSchedActProgram(bp BaseProgram) Program {
 	}
 }
 
-func (p *tcProgram) Attach(data interface{}) error {
-	return fmt.Errorf("Attach() not implemented for program type %s", p.BaseProgram.GetType())
+func (t TcFlowDirection) String() string {
+	switch t {
+	case TcDirectionIngress:
+		return "ingress"
+	case TcDirectionEgress:
+		return "egress"
+	default:
+		return "unknown"
+	}
 }
 
+// Convert a TcFlowDirection() to the parent qdisc handle that must be used
+// for a filter.
+func (t TcFlowDirection) Parent() uint32 {
+	switch t {
+	case TcDirectionIngress:
+		return netlink.HANDLE_MIN_INGRESS
+	case TcDirectionEgress:
+		return netlink.HANDLE_MIN_EGRESS
+	default:
+		panic("invalid state of TcFlowDirection")
+	}
+}
+
+// Attach an eBPF program to the clsact ingress or egress filter chain.
+// Takes a pointer to a TcAttachParams struct as an argument.
+func (p *tcProgram) Attach(data interface{}) error {
+	args, ok := data.(*TcAttachParams)
+	if !ok {
+		return fmt.Errorf("Failed to cast %T as TcAttachParams", data)
+	}
+
+	// Attach() cannot be called twice
+	if p.link != nil {
+		return fmt.Errorf("we already have a link being tracked, did you attempt to Attach() the same program twice?")
+	}
+
+	// Lookup interface
+	link, err := netlink.LinkByName(args.Interface)
+	if err != nil {
+		return fmt.Errorf("failed to lookup interface %q: %v", args.Interface, err)
+	}
+
+	// track link and direction
+	p.link = link
+	p.direction = args.Direction
+
+	switch p.programType {
+	case ProgramTypeSchedCls:
+		// SCHED_CLS programs get installed as filters.
+		// To do this, we need to install a special qdisc at handle ffff: called
+		// clsact.
+		// See: https://lwn.net/Articles/671458/
+
+		// check if there's already an ingress qdisc installed
+		ingressQdisc, err := getIngressQdisc(link)
+		if err != nil {
+			return fmt.Errorf("failed to check interface %q for ingress qdisc: %v", args.Interface, err)
+		}
+
+		if ingressQdisc != nil && ingressQdisc.Type() != "clsact" {
+			// if there is a qdisc with handle ffff: and it's not a clsact, require permission
+			// to clobber it since this will destroy existing rules.
+			if !args.ClobberIngress {
+				return fmt.Errorf("Refusing to clobber existing ffff: qdisc of type %q. Set "+
+					"args.ClobberIngress to true to allow this.", ingressQdisc.Type())
+			}
+
+			// delete the existing ingress qdisc
+			if err = netlink.QdiscDel(ingressQdisc); err != nil {
+				return fmt.Errorf("while removing ingress qdisc: %v", err)
+			}
+
+			// set to nil so the next block installs clsact
+			ingressQdisc = nil
+		}
+
+		if ingressQdisc == nil {
+			// this runs if either (1) there was no ffff: qdisc at all, or (2) there was
+			// an ingress qdisc on ffff: and we had permission to clobber it
+			if err = installClsActQdisc(link); err != nil {
+				return fmt.Errorf("failed to create clsact qdisc on interface %q: %v", args.Interface, err)
+			}
+		}
+
+		// we are ready to install the filter
+		err = p.installFilter(args)
+		if err != nil {
+			return err
+		}
+
+		break
+
+	case ProgramTypeSchedAct:
+		// SCHED_ACT programs get installed as actions.
+		// Currently unsupported.
+		return errors.New("TC_SCHED_ACT program support is not currently implemented.")
+	}
+
+	return nil
+}
+
+// Detach the running program from the filter chain or remove it from the actions
+// table.
 func (p *tcProgram) Detach() error {
-	return fmt.Errorf("Detach() not implemented for program type %s", p.BaseProgram.GetType())
+	if p.link == nil {
+		return fmt.Errorf("can't find link object, did Attach() succeed yet?")
+	}
+
+	switch p.programType {
+	case ProgramTypeSchedCls:
+		err := p.uninstallFilter()
+		if err != nil {
+			return nil
+		}
+
+		// We are done. The clsact qdisc can stay, it's a no-op if there are no filters.
+		break
+	case ProgramTypeSchedAct:
+		return errors.New("TC_SCHED_ACT program support is not currently implemented.")
+	}
+
+	p.link = nil
+	p.handle = 0
+
+	return nil
+}
+
+// Iterate through the list of filters under the parent object as determined by the
+// direction property (ingress or egress). Return the first handle greater than or
+// equal to HANDLE_FILTER_BASE that isn't used by an existing filter.
+func (p *tcProgram) getNextFilterHandle() (uint32, error) {
+	if p.link == nil {
+		return 0, errors.New("cannot iterate filters, link property is not yet set")
+	}
+
+	handle := HANDLE_FILTER_BASE
+	handles := make(map[uint32]interface{}, 0)
+
+	parent := p.direction.Parent()
+
+	filters, err := netlink.FilterList(p.link, parent)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, filter := range filters {
+		handles[filter.Attrs().Handle] = nil
+	}
+
+	for {
+		if _, ok := handles[handle]; !ok {
+			return handle, nil
+		}
+		handle += 1
+	}
+}
+
+// Insert a filter under either the ingress (ffff:fff2) or egress (ffff:fff3)
+// side of the clsact pseudo-qdisc. The handle is determined automatically from
+// the handles that are available.
+func (p *tcProgram) installFilter(args *TcAttachParams) error {
+	// will be 0xfffffff2 for ingress or 0xfffffff3 for ingress. See
+	// HANDLE_MIN_EGRESS and HANDLE_MIN_INGRESS in:
+	//    https://github.com/vishvananda/netlink/blob/main/qdisc.go
+	parent := p.direction.Parent()
+	// determine the handle to use for the filter
+	handle, err := p.getNextFilterHandle()
+	if err != nil {
+		return fmt.Errorf("while determining next available filter handle for program %q on interface %q: %v",
+			args.EntryPoint, args.Interface, err)
+	}
+
+	// construct the filter
+	filter := &netlink.BpfFilter{
+		FilterAttrs: netlink.FilterAttrs{
+			LinkIndex: p.link.Attrs().Index,
+			Parent:    parent,
+			Handle:    handle,
+			Protocol:  unix.ETH_P_ALL,
+			// FIXME(fuhry@2022-08-04): make tweakable?
+			Priority: 1,
+		},
+		Fd:           p.fd,
+		Name:         args.EntryPoint,
+		DirectAction: args.DirectAction,
+	}
+
+	if err = netlink.FilterAdd(filter); err != nil {
+		return fmt.Errorf("while loading egress program %q on fd %d: %v", args.EntryPoint, p.fd, err)
+	}
+
+	// track handle for later unload
+	p.handle = handle
+
+	return nil
+}
+
+// Uninstall the filter we previously added.
+func (p *tcProgram) uninstallFilter() error {
+	// need link and handle already stashed for this to work
+	if p.link == nil || p.handle == 0 {
+		return errors.New("link or handle not set, this can't be performed unless the program was successfully installed")
+	}
+
+	// list out current filters
+	parent := p.direction.Parent()
+	filters, err := netlink.FilterList(p.link, parent)
+	if err != nil {
+		return fmt.Errorf("while listing filters for uninstall: %v", err)
+	}
+
+	for _, filter := range filters {
+		// TODO(fuhry@2022-08-04) this matches only on the handle, also check type etc.?
+		if filter.Attrs().Handle == p.handle {
+			err = netlink.FilterDel(filter)
+			if err != nil {
+				return fmt.Errorf("while deleting filter %x from chain %x: %v", p.handle, parent, err)
+			}
+
+			// if this succeeded, clear the state before returning
+			p.handle = 0
+			p.link = nil
+			return nil
+		}
+	}
+
+	return fmt.Errorf("cannot find filter with handle %x to uninstall", p.handle)
+}
+
+// get the ingress or clsact pseudo-qdisc, if there is one.
+func getIngressQdisc(link netlink.Link) (netlink.Qdisc, error) {
+	qdiscs, err := netlink.QdiscList(link)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, qdisc := range qdiscs {
+		attrs := qdisc.Attrs()
+		if attrs.LinkIndex != link.Attrs().Index {
+			continue
+		}
+		if (attrs.Handle&0xFFFF0000) == 0xFFFF0000 && attrs.Parent == 0xFFFFFFF1 {
+			return qdisc, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// install the clsact qdisc
+func installClsActQdisc(link netlink.Link) error {
+	clsActAttrs := netlink.QdiscAttrs{
+		LinkIndex: link.Attrs().Index,
+		Handle:    HANDLE_INGRESS_QDISC,
+		Parent:    netlink.HANDLE_CLSACT,
+	}
+	clsActQdisc := &netlink.GenericQdisc{
+		QdiscAttrs: clsActAttrs,
+		QdiscType:  "clsact",
+	}
+
+	if err := netlink.QdiscAdd(clsActQdisc); err != nil {
+		return fmt.Errorf("while installing clsact qdisc: %v", err)
+	}
+
+	return nil
+
 }


### PR DESCRIPTION
Finish support for attaching BPF_PROG_TYPE_SCHED_CLS programs to the clsact pseudo-qdisc [1] in program_tc.

Implement an example packet counter under `examples/tc/packet_counter`.

[1] https://lwn.net/Articles/671458/

Signed-Off-By: Dan Fuhry <fuhry@dropbox.com>