### PR TITLE
Fix string lookups in the map loader

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -242,9 +242,15 @@ func loadAndCreateMaps(elfFile *elf.File) (map[string]Map, error) {
 				if err != nil {
 					return nil, fmt.Errorf("Unable to read '%s' section data: %v", sec.Name, err)
 				}
-				// Section data contains null terminated string and
-				// symbol.Value holds offset in this data
-				mapsByIndex[mapIndex].PersistentPath = NullTerminatedStringToString(sdata[relo.symbol.Value:])
+				// Section data contains null terminated string
+				// pointer to string value may be in either the symbol value or
+				// the pointer value within the struct itself
+				offset := mapsByIndex[mapIndex].persistentPathOffset
+				if offset == 0 && relo.symbol.Value > 0 {
+					offset = relo.symbol.Value
+				}
+				mapsByIndex[mapIndex].PersistentPath = NullTerminatedStringToString(
+					sdata[offset:])
 			} else {
 				return nil, fmt.Errorf("Unknown map RELO offset %d", mapOffset)
 			}

--- a/map.go
+++ b/map.go
@@ -265,6 +265,8 @@ type EbpfMap struct {
 	// WARNING: filesystem must be mounted as BPF
 	PersistentPath string
 
+	persistentPathOffset uint64
+
 	// In case of Per-CPU maps bpf_lookup call expects buffer equal to valueSize * nCPUs
 	// which will be populated with data from all possible CPUs
 	valueRealSize int
@@ -318,6 +320,10 @@ func newMapFromElfSection(data []byte) (*EbpfMap, error) {
 		ValueSize:  int(binary.LittleEndian.Uint32(data[8:])),
 		MaxEntries: int(binary.LittleEndian.Uint32(data[12:])),
 		Flags:      int(binary.LittleEndian.Uint32(data[16:])),
+		// NOTE(fuhry@2022-08-08): the bpf_map_def struct is not packed, so
+		// pointer fields are 8 bytes long and aligned to 8 byte boundaries.
+		// FIXME: handle different pointer sizes?
+		persistentPathOffset: uint64(binary.LittleEndian.Uint64(data[32:])),
 	}, nil
 }
 


### PR DESCRIPTION
It appears that at one time, the relocation section for `maps` listed
the offset of the string within `.rodata` in the relocation symbol's
`value` field. In an executable compiled with clang 14.0.6, the
relocation table's `value` property was zeroed, and the pointer to the
correct string was actually in the original struct.

Output of `objdump`/`readelf` demonstrating this behavior change will
be posted in a comment on this pull request.

This commit updates the map loader to track the pointer value. The map
parser uses the value from the relocation table entry if it's nonzero,
and otherwise uses the value directly from the struct definition in
the original `maps` section.

Signed-off-by: Dan Fuhry <fuhry@dropbox.com>