### PR TITLE
goebpf_mock: use __attribute__((weak)) on maps_head defs

### DIFF
--- a/goebpf_mock/mock_map.go
+++ b/goebpf_mock/mock_map.go
@@ -23,7 +23,7 @@ struct bpf_map_item {
 SLIST_HEAD(bpf_map_data_head, bpf_map_item);
 
 // Define previously declared list head
-struct __create_map_def maps_head;
+__attribute__((weak)) struct __create_map_def maps_head;
 struct __maps_head_def *__maps_head = (struct __maps_head_def*) &maps_head;
 
 static int is_map_type_array(struct bpf_map_def *def)

--- a/goebpf_mock/wrapper/wrapper.go
+++ b/goebpf_mock/wrapper/wrapper.go
@@ -11,7 +11,7 @@ package wrapper
 
 // Since eBPF mock package is optional and have definition of "__maps_head" symbol
 // it may cause link error, so defining weak symbol here as well
-struct __create_map_def maps_head;
+__attribute__((weak)) struct __create_map_def maps_head;
 __attribute__((weak)) struct __maps_head_def *__maps_head = (struct __maps_head_def*) &maps_head;
 
 BPF_MAP_DEF(map_hash) = {


### PR DESCRIPTION
Fixes compilation error that recently began to appear.

Signed-off-by: Dan Fuhry <fuhry@dropbox.com>