### PR TITLE
Apply gofmt 1.19 against repository

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -4,7 +4,7 @@
 /*
 Package goebpf provides simple and convenient interface to Linux eBPF system.
 
-Overview
+# Overview
 
 Extended Berkeley Packet Filter (eBPF) is a highly flexible and efficient virtual machine
 in the Linux kernel allowing to execute bytecode at various hook points in a safe manner.
@@ -19,7 +19,7 @@ Currently supported functionality:
 - Provides simple interface to interact with eBPF maps
 - Has mock versions of eBPF objects (program, map, etc) in order to make writing unittests simple.
 
-XDP
+# XDP
 
 eXpress Data Path - provides a bare metal, high performance, programmable packet processing
 at the closest at possible point to network driver. That makes it ideal for speed without
@@ -73,7 +73,7 @@ Once compiled can be used by goebpf in the following way:
 	    fmt.Printf("Drops: %d\n", val)
 	}
 
-PerfEvents
+# PerfEvents
 
 Perf Events (originally Performance Counters for Linux) is powerful kernel instrument for
 tracing, profiling and a lot of other cases like general events to user space.
@@ -119,7 +119,7 @@ A simple example could be to log all TCP SYN packets into user space from XDP pr
 		}
 	}
 
-Kprobes
+# Kprobes
 
 There are currently two types of supported probes: kprobes, and kretprobes
 (also called return probes). A kprobe can be inserted on virtually

--- a/loader.go
+++ b/loader.go
@@ -44,13 +44,14 @@ var sectionNameToProgramType = map[string]programCreator{
 
 // BPF instruction //
 // Must be in sync with linux/bpf.h:
-// 	struct bpf_insn {
-// 		__u8	code;		/* opcode */
-// 		__u8	dst_reg:4;	/* dest register */
-// 		__u8	src_reg:4;	/* source register */
-// 		__s16	off;		/* signed offset */
-// 		__s32	imm;		/* signed immediate constant */
-// 	};
+//
+//	struct bpf_insn {
+//		__u8	code;		/* opcode */
+//		__u8	dst_reg:4;	/* dest register */
+//		__u8	src_reg:4;	/* source register */
+//		__s16	off;		/* signed offset */
+//		__s32	imm;		/* signed immediate constant */
+//	};
 type bpfInstruction struct {
 	code   uint8  // Opcode
 	dstReg uint8  // 4 bits: destination register, r0-r10

--- a/map.go
+++ b/map.go
@@ -273,6 +273,7 @@ type EbpfMap struct {
 // CreateLPMtrieKey converts string representation of CIDR into net.IPNet
 // in order to support special eBPF map type: LPMtrie ("Longest Prefix Match Trie")
 // Can be used to match single IPv4/6 address with multiple CIDRs, like
+//
 //	m.Insert(CreateLPMtrieKey("192.168.0.0/16"), "value16")
 //	m.Insert(CreateLPMtrieKey("192.168.0.0/24"), "value24")
 //
@@ -694,7 +695,6 @@ func (m *EbpfMap) Update(ikey interface{}, ivalue interface{}) error {
 
 // Upsert updates (replaces) or inserts element at given ikey.
 // Supported ivalue types are: int, uint8, uint16, uint32, int32, uint64, string, []byte, net.IPNet
-//
 func (m *EbpfMap) Upsert(ikey interface{}, ivalue interface{}) error {
 	return m.updateImpl(ikey, ivalue, bpfAny)
 }

--- a/perf_events.go
+++ b/perf_events.go
@@ -52,20 +52,22 @@ type PerfEvents struct {
 
 // Go definition for C structs from
 // http://man7.org/linux/man-pages/man2/perf_event_open.2.html
-// struct perf_event_header {
-//     __u32   type;
-//     __u16   misc;
-//     __u16   size;
-// }
+//
+//	struct perf_event_header {
+//	    __u32   type;
+//	    __u16   misc;
+//	    __u16   size;
+//	}
 type perfEventHeader struct {
 	Type uint32
 	Misc uint16
 	Size uint16
 }
 
-// struct perf_event_lost {
-//     uint64_t id;
-//     uint64_t lost;
+//	struct perf_event_lost {
+//	    uint64_t id;
+//	    uint64_t lost;
+//
 // not added: struct sample_id sample_id;
 // }
 type perfEventLost struct {

--- a/program_kprobe.go
+++ b/program_kprobe.go
@@ -161,11 +161,11 @@ func newKretprobeProgram(bp BaseProgram) Program {
 // Attach attaches eBPF(Kprobe) program to a probe point.
 // There are 2 possible ways to do that:
 //
-// 1. Pass attach point as parameter, e.g.
-//    xdpProgram.Attach("SyS_execve")
+//  1. Pass attach point as parameter, e.g.
+//     xdpProgram.Attach("SyS_execve")
 //
-// 2. Using the ebpf program section identifier.
-//    SEC("kprobe/SyS_execve")
+//  2. Using the ebpf program section identifier.
+//     SEC("kprobe/SyS_execve")
 func (p *kprobeProgram) Attach(data interface{}) error {
 
 	// (optional) symbol override by parameter
@@ -227,7 +227,8 @@ func (p *kprobe) kprobePath(cmd string) string {
 
 // entry returns the relevant debugfs entry formatted string for the kprobe.
 // e.g. r4096:kretprobes/SyS_execve_goebpf_1234 SyS_execve
-//      <type_prefix|maxactive>:<type>/<label> <target_symbol>
+//
+//	<type_prefix|maxactive>:<type>/<label> <target_symbol>
 func (p *kprobe) entry() string {
 	prefix := p.attachType.Prefix()
 	if p.attachType == KprobeAttachTypeReturn {

--- a/program_xdp.go
+++ b/program_xdp.go
@@ -87,13 +87,13 @@ func newXdpProgram(bp BaseProgram) Program {
 // Attach attaches eBPF(XDP) program to network interface.
 // There are 2 possible ways to do that:
 //
-// 1. Pass interface name as parameter, e.g.
-//    xdpProgram.Attach("eth0")
+//  1. Pass interface name as parameter, e.g.
+//     xdpProgram.Attach("eth0")
 //
-// 2. Using XdpAttachParams structure:
-//    xdpProgram.Attach(
-//			&XdpAttachParams{Mode: XdpAttachModeSkb, Interface: "eth0"
-//    })
+//  2. Using XdpAttachParams structure:
+//     xdpProgram.Attach(
+//     &XdpAttachParams{Mode: XdpAttachModeSkb, Interface: "eth0"
+//     })
 func (p *xdpProgram) Attach(data interface{}) error {
 	var ifaceName string
 	var attachMode = XdpAttachModeNone // AutoSelect


### PR DESCRIPTION
Required to have checks start passing in #68.

Command run: `gofmt -s -l -w .`

Go version:

```
$ pacman -Q go
go 2:1.19-1
```

Signed-off-by: Dan Fuhry <fuhry@dropbox.com>