### PR TITLE
More robust path handling in tests

### DIFF
--- a/goebpf_mock/mock_map.go
+++ b/goebpf_mock/mock_map.go
@@ -6,12 +6,13 @@ package goebpf_mock
 // eBPF maps golang mock implementation for testing purposes.
 // The idea behind is make any BPF program unit-testable right from GO
 
+// #cgo CFLAGS: -I..
 /*
 #include <stdint.h>
 #include <sys/queue.h>
 #include <stdlib.h>
 
-#include "../bpf_helpers.h"
+#include "bpf_helpers.h"
 
 #define MAX_KEY_SIZE	32
 

--- a/goebpf_mock/wrapper/wrapper.go
+++ b/goebpf_mock/wrapper/wrapper.go
@@ -6,8 +6,9 @@
 // using import "C" from tests... :-(
 package wrapper
 
+// #cgo CFLAGS: -I../..
 /*
-#include "../../bpf_helpers.h"
+#include "bpf_helpers.h"
 
 // Since eBPF mock package is optional and have definition of "__maps_head" symbol
 // it may cause link error, so defining weak symbol here as well

--- a/itest/kprobe_test.go
+++ b/itest/kprobe_test.go
@@ -153,7 +153,7 @@ func (ts *kprobeTestSuite) TestKprobeEvents() {
 // Run suite
 func TestKprobeSuite(t *testing.T) {
 	suite.Run(t, &kprobeTestSuite{
-		programFilename: "ebpf_prog/kprobe1.elf",
+		programFilename: progPath("kprobe1.elf"),
 		programsCount:   2,
 		mapsCount:       1,
 	})

--- a/itest/path.go
+++ b/itest/path.go
@@ -1,0 +1,40 @@
+package itest
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+const progSubdir = "ebpf_prog"
+
+// Helper to get the absolute path of a test program.
+func progPath(imageName string) string {
+	// within `go test`, the test executable lives in a temporary directory, so
+	// we check the WD first.
+	exePath, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	relPath := path.Join(progSubdir, imageName)
+	wdPath := path.Join(wd, relPath)
+	absPath := path.Join(path.Dir(exePath), relPath)
+
+	if _, err = os.Stat(wdPath); err == nil {
+		return wdPath
+	}
+
+	if _, err = os.Stat(absPath); err == nil {
+		return absPath
+	}
+
+	panic(
+		fmt.Sprintf(
+			"eBPF executable not found, checked paths:\n  %q\n  %q",
+			wdPath, absPath))
+}

--- a/itest/perf_events_test.go
+++ b/itest/perf_events_test.go
@@ -17,7 +17,7 @@ import (
 func TestPerfEvents(t *testing.T) {
 	// Read ELF, find map, load/attach program
 	eb := goebpf.NewDefaultEbpfSystem()
-	err := eb.LoadElf(xdpProgramFilename)
+	err := eb.LoadElf(progPath(xdpProgramFilename))
 	require.NoError(t, err)
 	perfMap := eb.GetMapByName("perf_map")
 	require.NotNil(t, perfMap)

--- a/itest/tc_test.go
+++ b/itest/tc_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	tcProgramFilename = "ebpf_prog/tc1.elf"
+	tcProgramFilename = "tc1.elf"
 )
 
 type tcTestSuite struct {
@@ -129,7 +129,7 @@ func (ts *tcTestSuite) TestProgramInfo() {
 // Run suite
 func TestTcSuite(t *testing.T) {
 	suite.Run(t, &tcTestSuite{
-		programFilename: tcProgramFilename,
+		programFilename: progPath(tcProgramFilename),
 		programsCount:   3,
 	})
 }

--- a/itest/xdp_test.go
+++ b/itest/xdp_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	xdpProgramFilename = "ebpf_prog/xdp1.elf"
+	xdpProgramFilename = "xdp1.elf"
 )
 
 type xdpTestSuite struct {
@@ -204,7 +204,7 @@ func (ts *xdpTestSuite) TestProgramInfo() {
 // Run suite
 func TestXdpSuite(t *testing.T) {
 	suite.Run(t, &xdpTestSuite{
-		programFilename: xdpProgramFilename,
+		programFilename: progPath(xdpProgramFilename),
 		programsCount:   5,
 		mapsCount:       7,
 	})


### PR DESCRIPTION
Better handle situations where the working directory is not as expected. This PR specifically covers two scenarios:

1. Building parts of goebpf that use cgo when the working directory does not match the location of the target. We resolve this by removing relative paths anywhere `bpf_helpers.h` is included, instead passing that path as an `-I` argument to the compiler. This is done through a `#cgo` directive in the source but allows this to be overridden through other means such as a larger build system's CFLAGS.
2. Running the itest from a working directory other than `itest`. The tests now search the working directory first (preserving prior behavior) but also check for the image using the absolute path of the executable.