### PR TITLE
support expected_attach_type bpf_attr field

### DIFF
--- a/bpf.h
+++ b/bpf.h
@@ -92,6 +92,11 @@ union bpf_attr {
         __u32       prog_flags;
         char        prog_name[BPF_OBJ_NAME_LEN];
         __u32       prog_ifindex;   /* ifindex of netdev to prep for */
+        /* For some prog types expected attach type must be known at
+         * load time to verify attach type specific parts of prog
+         * (context accesses, allowed helpers, etc).
+         */
+        __u32        expected_attach_type;
     };
 
     struct { /* anonymous struct used by BPF_OBJ_* commands */

--- a/ebpf.go
+++ b/ebpf.go
@@ -49,6 +49,8 @@ type Program interface {
 	GetLicense() string
 	// Returns program type
 	GetType() ProgramType
+	// Returns expected attach type
+	GetExpectedAttachType() AttachType
 }
 
 // Map defines interface to interact with eBPF maps

--- a/program_base.go
+++ b/program_base.go
@@ -14,7 +14,8 @@ package goebpf
 
 // Load eBPF program into kernel
 static int ebpf_prog_load(const char *name, __u32 prog_type, const void *insns, __u32 insns_cnt,
-	const char *license, __u32 kern_version, void *log_buf, size_t log_size)
+	const char *license, __u32 kern_version, void *log_buf, size_t log_size,
+	__u32 expected_attach_type)
 {
 	union bpf_attr attr = {};
 
@@ -29,6 +30,7 @@ static int ebpf_prog_load(const char *name, __u32 prog_type, const void *insns, 
 	attr.log_size = 0;
 	attr.log_level = 0;
 	attr.kern_version = kern_version;
+	attr.expected_attach_type = expected_attach_type;
 	// program name
 	strncpy((char*)&attr.prog_name, name, BPF_OBJ_NAME_LEN - 1);
 
@@ -76,6 +78,69 @@ const (
 	ProgramTypeSockOps
 )
 
+// AttachType is eBPF program attach type
+type AttachType int
+
+// Must be in sync with enum bpf_attach_type from <linux/bpf.h>
+const (
+	AttachTypeCgroupInetIngress AttachType = iota
+	AttachTypeCgroupInetEgress
+	AttachTypeCgroupInetSockCreate
+	AttachTypeCgroupSockOps
+	AttachTypeSkSkbStreamParser
+	AttachTypeSkSkbStreamVerdict
+	AttachTypeCgroupDevice
+	AttachTypeSkMsgVerdict
+	AttachTypeCgroupInet4Bind
+	AttachTypeCgroupInet6Bind
+	AttachTypeCgroupInet4Connect
+	AttachTypeCgroupInet6Connect
+	AttachTypeCgroupInet4PostBind
+	AttachTypeCgroupInet6PostBind
+	AttachTypeCgroupUdp4Sendmsg
+	AttachTypeCgroupUdp6Sendmsg
+	AttachTypeLircMode2
+	AttachTypeFlowDissector
+	AttachTypeCgroupSysctl
+	AttachTypeCgroupUdp4Recvmsg
+	AttachTypeCgroupUdp6Recvmsg
+	AttachTypeCgroupGetsockopt
+	AttachTypeCgroupSetsockopt
+	AttachTypeTraceRawTp
+	AttachTypeTraceFentry
+	AttachTypeTraceFexit
+	AttachTypeModifyReturn
+	AttachTypeLsmMac
+	AttachTypeTraceIter
+	AttachTypeCgroupInet4Getpeername
+	AttachTypeCgroupInet6Getpeername
+	AttachTypeCgroupInet4Getsockname
+	AttachTypeCgroupInet6Getsockname
+	AttachTypeXdpDevmap
+	AttachTypeCgroupInetSockRelease
+	AttachTypeXdpCpumap
+	AttachTypeSkLookup
+	AttachTypeXdp
+	AttachTypeSkSkbVerdict
+	AttachTypeSkReuseportSelect
+	AttachTypeSkReuseportSelectOrMigrate
+	AttachTypePerfEvent
+	AttachTypeTraceKprobeMulti
+	AttachTypeLsmCgroup
+	AttachTypeStructOps
+	AttachTypeNetfilter
+	AttachTypeTcxIngress
+	AttachTypeTcxEgress
+	AttachTypeTraceUprobeMulti
+	AttachTypeCgroupUnixConnect
+	AttachTypeCgroupUnixSendmsg
+	AttachTypeCgroupUnixRecvmsg
+	AttachTypeCgroupUnixGetpeername
+	AttachTypeCgroupUnixGetsockname
+	AttachTypeNetkitPrimary
+	AttachTypeNetkitPeer
+)
+
 func (t ProgramType) String() string {
 	switch t {
 	case ProgramTypeSocketFilter:
@@ -118,6 +183,7 @@ type BaseProgram struct {
 	license       string // License
 	bytecode      []byte // eBPF instructions (each instruction - 8 bytes)
 	kernelVersion int    // Kernel requires version to match running for "kprobe" programs
+	attachType    AttachType
 }
 
 // Load loads program into linux kernel
@@ -144,8 +210,22 @@ func (prog *BaseProgram) Load() error {
 		license,
 		C.__u32(prog.kernelVersion),
 		unsafe.Pointer(&logBuf[0]),
-		C.size_t(unsafe.Sizeof(logBuf))))
+		C.size_t(unsafe.Sizeof(logBuf)),
+		C.__u32(prog.attachType)))
 
+	if res == -1 && int(prog.attachType) != 0 {
+		/* retry with expected_attach_type=0 in case kernel doesn't support it */
+		res = int(C.ebpf_prog_load(
+			name,
+			C.__u32(prog.GetType()),
+			unsafe.Pointer(&prog.bytecode[0]),
+			C.__u32(prog.GetSize())/bpfInstructionLen,
+			license,
+			C.__u32(prog.kernelVersion),
+			unsafe.Pointer(&logBuf[0]),
+			C.size_t(unsafe.Sizeof(logBuf)),
+			C.__u32(0)))
+	}
 	if res == -1 {
 		return fmt.Errorf("ebpf_prog_load() failed: %s",
 			NullTerminatedStringToString(logBuf[:]))
@@ -204,4 +284,9 @@ func (prog *BaseProgram) GetSize() int {
 // GetLicense returns program's license
 func (prog *BaseProgram) GetLicense() string {
 	return prog.license
+}
+
+// GetAttachType returns program's expected attach type
+func (prog *BaseProgram) GetExpectedAttachType() AttachType {
+	return prog.attachType
 }

--- a/program_xdp.go
+++ b/program_xdp.go
@@ -79,6 +79,7 @@ type xdpProgram struct {
 
 func newXdpProgram(bp BaseProgram) Program {
 	bp.programType = ProgramTypeXdp
+	bp.attachType = AttachTypeXdp
 	return &xdpProgram{
 		BaseProgram: bp,
 	}


### PR DESCRIPTION
The [expected_attach_type](https://elixir.bootlin.com/linux/v6.12.94/source/include/uapi/linux/bpf.h#L1548) struct field was added quite a while ago but was not enforced on tailcalls until torvalds/linux@4540aed51b12bc13364149bf95f6ecef013197c0 (CVE-2025-40123). On hosts with this patch applied, `bpf_map_update_elem` fails with `-EINVAL` when attempting to update a prog array map entry to a program with a non-matching `expected_attach_type`.

Add expected_attach_type arg to cgo API and pass via `bpf_attr`. Due to [bpf_check_uarg_tail_zero](https://github.com/torvalds/linux/blob/f31c00c377ccf07c85442712f7c940a855cb3371/kernel/bpf/syscall.c#L83-L113), automatically retry if program load fails with non-zero expected attach type.

libbpf equivalent: [bpf_program__set_expected_attach_type](https://docs.ebpf.io/ebpf-library/libbpf/userspace/bpf_program__set_expected_attach_type/)